### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/DDS.Tools/security/code-scanning/1](https://github.com/BoBoBaSs84/DDS.Tools/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege necessary. In this case, the workflow only needs to read repository contents, so set `contents: read` at the workflow root (above `jobs:`). This ensures all jobs in the workflow inherit these minimal permissions unless overridden. No other changes are needed, as none of the steps require write access.