### PR TITLE
feat: Refactor to remove IServiceProvider dependency

### DIFF
--- a/src/DDS.Tools/Commands/Base/ConvertCommandBase.cs
+++ b/src/DDS.Tools/Commands/Base/ConvertCommandBase.cs
@@ -13,8 +13,6 @@ using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Models;
 using DDS.Tools.Settings.Base;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -25,12 +23,18 @@ namespace DDS.Tools.Commands.Base;
 /// </summary>
 /// <inheritdoc/>
 /// <param name="todoService">The todo service instance to use.</param>
-/// <param name="serviceProvider">The service provier instance to use.</param>
-internal abstract class ConvertCommandBase<TSettings>(ITodoService todoService, IServiceProvider serviceProvider) : Command<TSettings> where TSettings : CommandSettings
+/// <param name="directoryProvider">The directory provider instance to use.</param>
+/// <param name="fileProvider">The file provider instance to use.</param>
+/// <param name="pathProvider">The path provider instance to use.</param>
+internal abstract class ConvertCommandBase<TSettings>(
+	ITodoService todoService,
+	IDirectoryProvider directoryProvider,
+	IFileProvider fileProvider,
+	IPathProvider pathProvider) : Command<TSettings> where TSettings : CommandSettings
 {
-	private readonly IDirectoryProvider _directoryProvider = serviceProvider.GetRequiredService<IDirectoryProvider>();
-	private readonly IFileProvider _fileProvider = serviceProvider.GetRequiredService<IFileProvider>();
-	private readonly IPathProvider _pathProvider = serviceProvider.GetRequiredService<IPathProvider>();
+	private readonly IDirectoryProvider _directoryProvider = directoryProvider;
+	private readonly IFileProvider _fileProvider = fileProvider;
+	private readonly IPathProvider _pathProvider = pathProvider;
 
 	protected int Action(ConvertSettingsBase settings, ImageType imageType)
 	{

--- a/src/DDS.Tools/Commands/DdsConvertCommand.cs
+++ b/src/DDS.Tools/Commands/DdsConvertCommand.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using DDS.Tools.Commands.Base;
 using DDS.Tools.Enumerators;
+using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Settings;
 
@@ -24,9 +25,16 @@ namespace DDS.Tools.Commands;
 /// </summary>
 /// <param name="loggerService">The logger service instance to use.</param>
 /// <param name="todoService">The todo service instance to use.</param>
-/// <param name="serviceProvider">The service provier instance to use.</param>
-internal sealed class DdsConvertCommand(ILoggerService<DdsConvertCommand> loggerService, ITodoService todoService, IServiceProvider serviceProvider)
-	: ConvertCommandBase<DdsConvertSettings>(todoService, serviceProvider)
+/// <param name="directoryProvider">The directory provider instance to use.</param>
+/// <param name="fileProvider">The file provider instance to use.</param>
+/// <param name="pathProvider">The path provider instance to use.</param>
+internal sealed class DdsConvertCommand(
+	ILoggerService<DdsConvertCommand> loggerService,
+	ITodoService todoService,
+	IDirectoryProvider directoryProvider,
+	IFileProvider fileProvider,
+	IPathProvider pathProvider)
+	: ConvertCommandBase<DdsConvertSettings>(todoService, directoryProvider, fileProvider, pathProvider)
 {
 	private const ImageType Type = ImageType.DDS;
 	private readonly ILoggerService<DdsConvertCommand> _loggerService = loggerService;

--- a/src/DDS.Tools/Commands/PngConvertCommand.cs
+++ b/src/DDS.Tools/Commands/PngConvertCommand.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using DDS.Tools.Commands.Base;
 using DDS.Tools.Enumerators;
+using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Settings;
 
@@ -24,9 +25,16 @@ namespace DDS.Tools.Commands;
 /// </summary>
 /// <param name="loggerService">The logger service instance to use.</param>
 /// <param name="todoService">The todo service instance to use.</param>
-/// <param name="serviceProvider">The service provier instance to use.</param>
-internal sealed class PngConvertCommand(ILoggerService<DdsConvertCommand> loggerService, ITodoService todoService, IServiceProvider serviceProvider)
-	: ConvertCommandBase<PngConvertSettings>(todoService, serviceProvider)
+/// <param name="directoryProvider">The directory provider instance to use.</param>
+/// <param name="fileProvider">The file provider instance to use.</param>
+/// <param name="pathProvider">The path provider instance to use.</param>
+internal sealed class PngConvertCommand(
+	ILoggerService<DdsConvertCommand> loggerService,
+	ITodoService todoService,
+	IDirectoryProvider directoryProvider,
+	IFileProvider fileProvider,
+	IPathProvider pathProvider)
+	: ConvertCommandBase<PngConvertSettings>(todoService, directoryProvider, fileProvider, pathProvider)
 {
 	private const ImageType Type = ImageType.PNG;
 	private readonly ILoggerService<DdsConvertCommand> _loggerService = loggerService;

--- a/src/DDS.Tools/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DDS.Tools/Extensions/ServiceCollectionExtensions.cs
@@ -16,7 +16,6 @@ using DDS.Tools.Providers;
 using DDS.Tools.Services;
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -38,23 +37,26 @@ internal static class ServiceCollectionExtensions
 	{
 		services.RegisterLoggerService(environment);
 
-		services.TryAddSingleton<DdsEncoder>();
-		services.TryAddSingleton<DdsDecoder>();
-		services.TryAddSingleton<ITodoService, TodoService>();
+		services.AddSingleton<DdsEncoder>();
+		services.AddSingleton<DdsDecoder>();
+		services.AddSingleton<ITodoService, TodoService>();
 
-		services.TryAddSingleton<IDirectoryProvider, DirectoryProvider>();
-		services.TryAddSingleton<IFileProvider, FileProvider>();
-		services.TryAddSingleton<IPathProvider, PathProvider>();
+		services.AddSingleton<IDirectoryProvider, DirectoryProvider>();
+		services.AddSingleton<IFileProvider, FileProvider>();
+		services.AddSingleton<IPathProvider, PathProvider>();
 
-		services.TryAddKeyedTransient<IImageModel, PngImageModel>(ImageType.PNG);
-		services.TryAddKeyedTransient<IImageModel, DdsImageModel>(ImageType.DDS);
+		services.AddKeyedTransient<IImageModel, PngImageModel>(ImageType.PNG);
+		services.AddKeyedTransient<IImageModel, DdsImageModel>(ImageType.DDS);
+
+		services.AddSingleton<Func<ImageType, IImageModel>>(serviceProvider
+			=> imageType => serviceProvider.GetRequiredKeyedService<IImageModel>(imageType));
 
 		return services;
 	}
 
 	private static IServiceCollection RegisterLoggerService(this IServiceCollection services, IHostEnvironment environment)
 	{
-		services.TryAddSingleton(typeof(ILoggerService<>), typeof(LoggerService<>));
+		services.AddSingleton(typeof(ILoggerService<>), typeof(LoggerService<>));
 
 		services.AddLogging(configure =>
 		{

--- a/src/DDS.Tools/Services/TodoService.cs
+++ b/src/DDS.Tools/Services/TodoService.cs
@@ -18,7 +18,6 @@ using DDS.Tools.Models;
 using DDS.Tools.Properties;
 using DDS.Tools.Settings.Base;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Spectre.Console;
@@ -29,14 +28,22 @@ namespace DDS.Tools.Services;
 /// The todo service class.
 /// </summary>
 /// <param name="loggerService">The logger service instance to use.</param>
-/// <param name="serviceProvider">The service provider instance to use.</param>
-internal sealed class TodoService(ILoggerService<TodoService> loggerService, IServiceProvider serviceProvider) : ITodoService
+/// <param name="directoryProvider">The directory provider instance to use.</param>
+/// <param name="fileProvider">The file provider instance to use.</param>
+/// <param name="pathProvider">The path provider instance to use.</param>
+/// <param name="imageModelFactory">The image model factory instance to use.</param>
+internal sealed class TodoService(
+	ILoggerService<TodoService> loggerService,
+	IDirectoryProvider directoryProvider,
+	IFileProvider fileProvider,
+	IPathProvider pathProvider,
+	Func<ImageType, IImageModel> imageModelFactory) : ITodoService
 {
-	private readonly IDirectoryProvider _directoryProvider = serviceProvider.GetRequiredService<IDirectoryProvider>();
-	private readonly IFileProvider _fileProvider = serviceProvider.GetRequiredService<IFileProvider>();
-	private readonly IPathProvider _pathProvider = serviceProvider.GetRequiredService<IPathProvider>();
+	private readonly IDirectoryProvider _directoryProvider = directoryProvider;
+	private readonly IFileProvider _fileProvider = fileProvider;
+	private readonly IPathProvider _pathProvider = pathProvider;
+	private readonly Func<ImageType, IImageModel> _imageModelFactory = imageModelFactory;
 	private readonly ILoggerService<TodoService> _loggerService = loggerService;
-	private readonly IServiceProvider _serviceProvider = serviceProvider;
 
 	private readonly List<string> _todosDone = [];
 	private int _todosDuplicateCount = 0;
@@ -121,7 +128,7 @@ internal sealed class TodoService(ILoggerService<TodoService> loggerService, ISe
 	{
 		FileInfo fileInfo = new(file);
 
-		IImageModel image = _serviceProvider.GetRequiredKeyedService<IImageModel>(imageType);
+		IImageModel image = _imageModelFactory(imageType);
 		image.Load(file);
 
 		TodoModel todo = new(
@@ -183,7 +190,7 @@ internal sealed class TodoService(ILoggerService<TodoService> loggerService, ISe
 
 	private void CopyImage(ConvertSettingsBase settings, TodoModel todo, ImageType imageType)
 	{
-		IImageModel image = _serviceProvider.GetRequiredKeyedService<IImageModel>(imageType);
+		IImageModel image = _imageModelFactory(imageType);
 		image.Load(todo.FullPathName);
 
 		string targetFolder = PrepareTargetFolder(settings, image, todo);
@@ -200,7 +207,7 @@ internal sealed class TodoService(ILoggerService<TodoService> loggerService, ISe
 
 	private void SaveImage(ConvertSettingsBase settings, TodoModel todo, ImageType imageType)
 	{
-		IImageModel image = _serviceProvider.GetRequiredKeyedService<IImageModel>(imageType);
+		IImageModel image = _imageModelFactory(imageType);
 		image.Load(todo.FullPathName);
 
 		string targetFolder = PrepareTargetFolder(settings, image, todo);

--- a/tests/DDS.Tools.Tests/Commands/Base/ConvertCommandBaseTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/Base/ConvertCommandBaseTests.cs
@@ -14,8 +14,6 @@ using DDS.Tools.Models;
 using DDS.Tools.Settings;
 using DDS.Tools.Settings.Base;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Moq;
 
 using Spectre.Console.Cli;
@@ -36,8 +34,7 @@ public sealed class ConvertCommandBaseTests
 		DdsConvertSettings settings = new() { SourceFolder = @"X:\Missing", TargetFolder = @"X:\Target" };
 		directoryProviderMock.Setup(x => x.Exists(settings.SourceFolder)).Returns(false);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		TestConvertCommand command = new(todoServiceMock.Object, serviceProvider);
+		TestConvertCommand command = new(todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		Assert.Throws<CommandException>(() => command.InvokeAction(settings, ImageType.DDS));
 
@@ -62,8 +59,7 @@ public sealed class ConvertCommandBaseTests
 		fileProviderMock.Setup(x => x.Exists(@"X:\Source\Result.json")).Returns(false);
 		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.DDS)).Returns(todos);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		TestConvertCommand command = new(todoServiceMock.Object, serviceProvider);
+		TestConvertCommand command = new(todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = command.InvokeAction(settings, ImageType.DDS);
 
@@ -95,8 +91,7 @@ public sealed class ConvertCommandBaseTests
 		fileProviderMock.Setup(x => x.ReadAllText(JsonPath)).Returns(JsonContent);
 		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.DDS, JsonContent)).Returns(todos);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		TestConvertCommand command = new(todoServiceMock.Object, serviceProvider);
+		TestConvertCommand command = new(todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = command.InvokeAction(settings, ImageType.DDS);
 
@@ -107,17 +102,12 @@ public sealed class ConvertCommandBaseTests
 		todoServiceMock.Verify(x => x.GetTodosDone(todos, settings, ImageType.DDS, true), Times.Once);
 	}
 
-	private static ServiceProvider CreateServiceProvider(IDirectoryProvider directoryProvider, IFileProvider fileProvider, IPathProvider pathProvider)
-	{
-		ServiceCollection services = new();
-		services.AddSingleton(directoryProvider);
-		services.AddSingleton(fileProvider);
-		services.AddSingleton(pathProvider);
-		return services.BuildServiceProvider();
-	}
-
-	private sealed class TestConvertCommand(ITodoService todoService, IServiceProvider serviceProvider)
-		: ConvertCommandBase<DdsConvertSettings>(todoService, serviceProvider)
+	private sealed class TestConvertCommand(
+		ITodoService todoService,
+		IDirectoryProvider directoryProvider,
+		IFileProvider fileProvider,
+		IPathProvider pathProvider)
+		: ConvertCommandBase<DdsConvertSettings>(todoService, directoryProvider, fileProvider, pathProvider)
 	{
 		public int InvokeAction(ConvertSettingsBase settings, ImageType imageType)
 			=> Action(settings, imageType);

--- a/tests/DDS.Tools.Tests/Commands/DdsConvertCommandTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/DdsConvertCommandTests.cs
@@ -15,8 +15,6 @@ using DDS.Tools.Models;
 using DDS.Tools.Settings;
 using DDS.Tools.Settings.Base;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Moq;
 
 namespace DDS.Tools.Tests.Commands;
@@ -45,8 +43,7 @@ public sealed class DdsConvertCommandTests
 		fileProviderMock.Setup(x => x.Exists(@"X:\Source\Result.json")).Returns(false);
 		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.DDS)).Returns(todos);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		DdsConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, serviceProvider);
+		DdsConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = InvokeExecute(command, settings);
 
@@ -73,8 +70,7 @@ public sealed class DdsConvertCommandTests
 
 		directoryProviderMock.Setup(x => x.Exists(settings.SourceFolder)).Returns(false);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		DdsConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, serviceProvider);
+		DdsConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = InvokeExecute(command, settings);
 
@@ -98,12 +94,4 @@ public sealed class DdsConvertCommandTests
 		return todos;
 	}
 
-	private static ServiceProvider CreateServiceProvider(IDirectoryProvider directoryProvider, IFileProvider fileProvider, IPathProvider pathProvider)
-	{
-		ServiceCollection services = new();
-		services.AddSingleton(directoryProvider);
-		services.AddSingleton(fileProvider);
-		services.AddSingleton(pathProvider);
-		return services.BuildServiceProvider();
-	}
 }

--- a/tests/DDS.Tools.Tests/Commands/PngConvertCommandTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/PngConvertCommandTests.cs
@@ -15,8 +15,6 @@ using DDS.Tools.Models;
 using DDS.Tools.Settings;
 using DDS.Tools.Settings.Base;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Moq;
 
 namespace DDS.Tools.Tests.Commands;
@@ -45,8 +43,7 @@ public sealed class PngConvertCommandTests
 		fileProviderMock.Setup(x => x.Exists(@"X:\Source\Result.json")).Returns(false);
 		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.PNG)).Returns(todos);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		PngConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, serviceProvider);
+		PngConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = InvokeExecute(command, settings);
 
@@ -73,8 +70,7 @@ public sealed class PngConvertCommandTests
 
 		directoryProviderMock.Setup(x => x.Exists(settings.SourceFolder)).Returns(false);
 
-		IServiceProvider serviceProvider = CreateServiceProvider(directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
-		PngConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, serviceProvider);
+		PngConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = InvokeExecute(command, settings);
 
@@ -98,12 +94,4 @@ public sealed class PngConvertCommandTests
 		return todos;
 	}
 
-	private static ServiceProvider CreateServiceProvider(IDirectoryProvider directoryProvider, IFileProvider fileProvider, IPathProvider pathProvider)
-	{
-		ServiceCollection services = new();
-		services.AddSingleton(directoryProvider);
-		services.AddSingleton(fileProvider);
-		services.AddSingleton(pathProvider);
-		return services.BuildServiceProvider();
-	}
 }

--- a/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
@@ -15,7 +15,6 @@ using DDS.Tools.Services;
 using DDS.Tools.Settings;
 using DDS.Tools.Settings.Base;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -210,19 +209,12 @@ public sealed class TodoServiceTests
 	}
 
 	private TodoService CreateSut()
-	{
-		ServiceCollection services = new();
-
-		services.AddSingleton(_directoryProviderMock.Object);
-		services.AddSingleton(_fileProviderMock.Object);
-		services.AddSingleton(_pathProviderMock.Object);
-		services.AddKeyedSingleton<IImageModel>(ImageType.DDS, _imageModelMock.Object);
-		services.AddKeyedSingleton<IImageModel>(ImageType.PNG, _imageModelMock.Object);
-
-		ServiceProvider provider = services.BuildServiceProvider();
-
-		return new TodoService(_loggerServiceMock.Object, provider);
-	}
+	 => new(
+			_loggerServiceMock.Object,
+			_directoryProviderMock.Object,
+			_fileProviderMock.Object,
+			_pathProviderMock.Object,
+			_ => _imageModelMock.Object);
 
 	private void ConfigureCommonMocks()
 	{


### PR DESCRIPTION
**Changes:**

- Replaced IServiceProvider with explicit constructor injection across multiple classes (`ConvertCommandBase`, `DdsConvertCommand`, `PngConvertCommand`, `TodoService`, etc.) to improve dependency clarity and reduce reliance on the service locator pattern.
- Updated service registration in `ServiceCollectionExtensions` to use `AddSingleton` and added a factory for resolving `IImageModel` instances by `ImageType`.
- Refactored unit tests to directly inject mocked dependencies, removing the need for `IServiceProvider` in test setups.
- Simplified test setup and improved alignment with updated constructor signatures.
- Removed unnecessary `using` statements and improved code readability and maintainability by adhering to the Dependency Inversion Principle.

closes #224 