### PR TITLE
feat: Refactor logging in `ConvertCommandBase` hierarchy

### DIFF
--- a/src/DDS.Tools/Commands/Base/ConvertCommandBase.cs
+++ b/src/DDS.Tools/Commands/Base/ConvertCommandBase.cs
@@ -13,6 +13,8 @@ using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Models;
 using DDS.Tools.Settings.Base;
 
+using Microsoft.Extensions.Logging;
+
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -22,19 +24,43 @@ namespace DDS.Tools.Commands.Base;
 /// The convert command base class.
 /// </summary>
 /// <inheritdoc/>
+/// <param name="loggerService">The logger service instance to use.</param>
 /// <param name="todoService">The todo service instance to use.</param>
 /// <param name="directoryProvider">The directory provider instance to use.</param>
 /// <param name="fileProvider">The file provider instance to use.</param>
 /// <param name="pathProvider">The path provider instance to use.</param>
-internal abstract class ConvertCommandBase<TSettings>(
+internal abstract class ConvertCommandBase<TSettings, TCommand>(
+	ILoggerService<TCommand> loggerService,
 	ITodoService todoService,
 	IDirectoryProvider directoryProvider,
 	IFileProvider fileProvider,
-	IPathProvider pathProvider) : Command<TSettings> where TSettings : CommandSettings
+	IPathProvider pathProvider) : Command<TSettings>
+	where TSettings : CommandSettings
+	where TCommand : class
 {
+	private readonly ILoggerService<TCommand> _loggerService = loggerService;
 	private readonly IDirectoryProvider _directoryProvider = directoryProvider;
 	private readonly IFileProvider _fileProvider = fileProvider;
 	private readonly IPathProvider _pathProvider = pathProvider;
+
+	private static readonly Action<ILogger, Exception?> LogException =
+		LoggerMessage.Define(LogLevel.Error, 0, "Exception occured.");
+
+	protected int ExecuteCommand(ConvertSettingsBase settings, ImageType imageType)
+	{
+		try
+		{
+			return AnsiConsole.Status()
+				.Spinner(Spinner.Known.Line)
+				.Start("Processing..", action => Action(settings, imageType));
+		}
+		catch (Exception ex)
+		{
+			_loggerService.Log(LogException, ex);
+			AnsiConsole.MarkupLine($"[maroon]{ex.Message}[/]");
+			return 1;
+		}
+	}
 
 	protected int Action(ConvertSettingsBase settings, ImageType imageType)
 	{

--- a/src/DDS.Tools/Commands/DdsConvertCommand.cs
+++ b/src/DDS.Tools/Commands/DdsConvertCommand.cs
@@ -13,9 +13,6 @@ using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Settings;
 
-using Microsoft.Extensions.Logging;
-
-using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace DDS.Tools.Commands;
@@ -34,28 +31,11 @@ internal sealed class DdsConvertCommand(
 	IDirectoryProvider directoryProvider,
 	IFileProvider fileProvider,
 	IPathProvider pathProvider)
-	: ConvertCommandBase<DdsConvertSettings>(todoService, directoryProvider, fileProvider, pathProvider)
+	: ConvertCommandBase<DdsConvertSettings, DdsConvertCommand>(loggerService, todoService, directoryProvider, fileProvider, pathProvider)
 {
 	private const ImageType Type = ImageType.DDS;
-	private readonly ILoggerService<DdsConvertCommand> _loggerService = loggerService;
-
-	private static readonly Action<ILogger, Exception?> LogException =
-		LoggerMessage.Define(LogLevel.Error, 0, "Exception occured.");
 
 	/// <inheritdoc/>
 	protected override int Execute([NotNull] CommandContext context, [NotNull] DdsConvertSettings settings, CancellationToken cancellationToken)
-	{
-		try
-		{
-			return AnsiConsole.Status()
-				.Spinner(Spinner.Known.Line)
-				.Start("Processing..", action => Action(settings, Type));
-		}
-		catch (Exception ex)
-		{
-			_loggerService.Log(LogException, ex);
-			AnsiConsole.MarkupLine($"[maroon]{ex.Message}[/]");
-			return 1;
-		}
-	}
+	 => ExecuteCommand(settings, Type);
 }

--- a/src/DDS.Tools/Commands/PngConvertCommand.cs
+++ b/src/DDS.Tools/Commands/PngConvertCommand.cs
@@ -13,9 +13,6 @@ using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Settings;
 
-using Microsoft.Extensions.Logging;
-
-using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace DDS.Tools.Commands;
@@ -29,33 +26,16 @@ namespace DDS.Tools.Commands;
 /// <param name="fileProvider">The file provider instance to use.</param>
 /// <param name="pathProvider">The path provider instance to use.</param>
 internal sealed class PngConvertCommand(
-	ILoggerService<DdsConvertCommand> loggerService,
+	ILoggerService<PngConvertCommand> loggerService,
 	ITodoService todoService,
 	IDirectoryProvider directoryProvider,
 	IFileProvider fileProvider,
 	IPathProvider pathProvider)
-	: ConvertCommandBase<PngConvertSettings>(todoService, directoryProvider, fileProvider, pathProvider)
+	: ConvertCommandBase<PngConvertSettings, PngConvertCommand>(loggerService, todoService, directoryProvider, fileProvider, pathProvider)
 {
 	private const ImageType Type = ImageType.PNG;
-	private readonly ILoggerService<DdsConvertCommand> _loggerService = loggerService;
-
-	private static readonly Action<ILogger, Exception?> LogException =
-		LoggerMessage.Define(LogLevel.Error, 0, "Exception occured.");
 
 	/// <inheritdoc/>
 	protected override int Execute([NotNull] CommandContext context, [NotNull] PngConvertSettings settings, CancellationToken cancellationToken)
-	{
-		try
-		{
-			return AnsiConsole.Status()
-				.Spinner(Spinner.Known.Line)
-				.Start("Processing..", action => Action(settings, Type));
-		}
-		catch (Exception ex)
-		{
-			_loggerService.Log(LogException, ex);
-			AnsiConsole.MarkupLine($"[maroon]{ex.Message}[/]");
-			return 1;
-		}
-	}
+	 => ExecuteCommand(settings, Type);
 }

--- a/tests/DDS.Tools.Tests/Commands/Base/ConvertCommandBaseTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/Base/ConvertCommandBaseTests.cs
@@ -5,6 +5,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
+using DDS.Tools.Commands;
 using DDS.Tools.Commands.Base;
 using DDS.Tools.Enumerators;
 using DDS.Tools.Exceptions;
@@ -26,6 +27,7 @@ public sealed class ConvertCommandBaseTests
 	[TestMethod]
 	public void ActionSourceFolderMissingThrowsCommandException()
 	{
+		Mock<ILoggerService<DdsConvertCommand>> loggerServiceMock = new();
 		Mock<ITodoService> todoServiceMock = new();
 		Mock<IDirectoryProvider> directoryProviderMock = new();
 		Mock<IFileProvider> fileProviderMock = new();
@@ -34,7 +36,7 @@ public sealed class ConvertCommandBaseTests
 		DdsConvertSettings settings = new() { SourceFolder = @"X:\Missing", TargetFolder = @"X:\Target" };
 		directoryProviderMock.Setup(x => x.Exists(settings.SourceFolder)).Returns(false);
 
-		TestConvertCommand command = new(todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
+		TestConvertCommand command = new(loggerServiceMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		Assert.Throws<CommandException>(() => command.InvokeAction(settings, ImageType.DDS));
 
@@ -46,6 +48,7 @@ public sealed class ConvertCommandBaseTests
 	[TestMethod]
 	public void ActionWithoutJsonAndWithoutTodosReturnsOne()
 	{
+		Mock<ILoggerService<DdsConvertCommand>> loggerServiceMock = new();
 		Mock<ITodoService> todoServiceMock = new();
 		Mock<IDirectoryProvider> directoryProviderMock = new();
 		Mock<IFileProvider> fileProviderMock = new();
@@ -59,7 +62,7 @@ public sealed class ConvertCommandBaseTests
 		fileProviderMock.Setup(x => x.Exists(@"X:\Source\Result.json")).Returns(false);
 		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.DDS)).Returns(todos);
 
-		TestConvertCommand command = new(todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
+		TestConvertCommand command = new(loggerServiceMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = command.InvokeAction(settings, ImageType.DDS);
 
@@ -73,6 +76,7 @@ public sealed class ConvertCommandBaseTests
 	[TestMethod]
 	public void ActionWithJsonUsesJsonOverloadAndReturnsZero()
 	{
+		Mock<ILoggerService<DdsConvertCommand>> loggerServiceMock = new();
 		Mock<ITodoService> todoServiceMock = new();
 		Mock<IDirectoryProvider> directoryProviderMock = new();
 		Mock<IFileProvider> fileProviderMock = new();
@@ -91,7 +95,7 @@ public sealed class ConvertCommandBaseTests
 		fileProviderMock.Setup(x => x.ReadAllText(JsonPath)).Returns(JsonContent);
 		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.DDS, JsonContent)).Returns(todos);
 
-		TestConvertCommand command = new(todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
+		TestConvertCommand command = new(loggerServiceMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
 
 		int result = command.InvokeAction(settings, ImageType.DDS);
 
@@ -103,11 +107,12 @@ public sealed class ConvertCommandBaseTests
 	}
 
 	private sealed class TestConvertCommand(
+		ILoggerService<DdsConvertCommand> loggerService,
 		ITodoService todoService,
 		IDirectoryProvider directoryProvider,
 		IFileProvider fileProvider,
 		IPathProvider pathProvider)
-		: ConvertCommandBase<DdsConvertSettings>(todoService, directoryProvider, fileProvider, pathProvider)
+	 : ConvertCommandBase<DdsConvertSettings, DdsConvertCommand>(loggerService, todoService, directoryProvider, fileProvider, pathProvider)
 	{
 		public int InvokeAction(ConvertSettingsBase settings, ImageType imageType)
 			=> Action(settings, imageType);

--- a/tests/DDS.Tools.Tests/Commands/DdsConvertCommandTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/DdsConvertCommandTests.cs
@@ -80,6 +80,36 @@ public sealed class DdsConvertCommandTests
 		todoServiceMock.Verify(x => x.GetTodosDone(It.IsAny<TodoCollection>(), It.IsAny<ConvertSettingsBase>(), It.IsAny<ImageType>(), It.IsAny<bool>()), Times.Never);
 	}
 
+	[TestMethod]
+	public void DdsConvertCommandExecuteWhenTodoServiceThrowsLogsExceptionAndReturnsOne()
+	{
+		Mock<ILoggerService<DdsConvertCommand>> loggerMock = new();
+		Mock<ITodoService> todoServiceMock = new();
+		Mock<IDirectoryProvider> directoryProviderMock = new();
+		Mock<IFileProvider> fileProviderMock = new();
+		Mock<IPathProvider> pathProviderMock = new();
+
+		DdsConvertSettings settings = new()
+		{
+			SourceFolder = @"X:\Source",
+			TargetFolder = @"X:\Target"
+		};
+
+		directoryProviderMock.Setup(x => x.Exists(settings.SourceFolder)).Returns(true);
+		pathProviderMock.Setup(x => x.Combine(settings.SourceFolder, "Result.json")).Returns(@"X:\Source\Result.json");
+		fileProviderMock.Setup(x => x.Exists(@"X:\Source\Result.json")).Returns(false);
+		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.DDS)).Throws(new InvalidOperationException("boom"));
+
+		DdsConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
+
+		int result = InvokeExecute(command, settings);
+
+		Assert.AreEqual(1, result);
+		loggerMock.Verify(x => x.Log(It.IsAny<Action<Microsoft.Extensions.Logging.ILogger, Exception?>>(), It.IsAny<Exception?>()), Times.Once);
+		todoServiceMock.Verify(x => x.GetTodos(settings, ImageType.DDS), Times.Once);
+		todoServiceMock.Verify(x => x.GetTodosDone(It.IsAny<TodoCollection>(), It.IsAny<ConvertSettingsBase>(), It.IsAny<ImageType>(), It.IsAny<bool>()), Times.Never);
+	}
+
 	private static int InvokeExecute(DdsConvertCommand command, DdsConvertSettings settings)
 	{
 		MethodInfo method = typeof(DdsConvertCommand).GetMethod("Execute", BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -93,5 +123,4 @@ public sealed class DdsConvertCommandTests
 		todos.Enqueue(new TodoModel("32.dds", string.Empty, @"X:\Source\32.dds", @"X:\Target", "HASH-1"));
 		return todos;
 	}
-
 }

--- a/tests/DDS.Tools.Tests/Commands/PngConvertCommandTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/PngConvertCommandTests.cs
@@ -25,7 +25,7 @@ public sealed class PngConvertCommandTests
 	[TestMethod]
 	public void PngConvertCommandExecuteSuccessTest()
 	{
-		Mock<ILoggerService<DdsConvertCommand>> loggerMock = new();
+		Mock<ILoggerService<PngConvertCommand>> loggerMock = new();
 		Mock<ITodoService> todoServiceMock = new();
 		Mock<IDirectoryProvider> directoryProviderMock = new();
 		Mock<IFileProvider> fileProviderMock = new();
@@ -56,7 +56,7 @@ public sealed class PngConvertCommandTests
 	[TestMethod]
 	public void PngConvertCommandExecuteExceptionTest()
 	{
-		Mock<ILoggerService<DdsConvertCommand>> loggerMock = new();
+		Mock<ILoggerService<PngConvertCommand>> loggerMock = new();
 		Mock<ITodoService> todoServiceMock = new();
 		Mock<IDirectoryProvider> directoryProviderMock = new();
 		Mock<IFileProvider> fileProviderMock = new();
@@ -80,6 +80,36 @@ public sealed class PngConvertCommandTests
 		todoServiceMock.Verify(x => x.GetTodosDone(It.IsAny<TodoCollection>(), It.IsAny<ConvertSettingsBase>(), It.IsAny<ImageType>(), It.IsAny<bool>()), Times.Never);
 	}
 
+	[TestMethod]
+	public void PngConvertCommandExecuteWhenTodoServiceThrowsLogsExceptionAndReturnsOne()
+	{
+		Mock<ILoggerService<PngConvertCommand>> loggerMock = new();
+		Mock<ITodoService> todoServiceMock = new();
+		Mock<IDirectoryProvider> directoryProviderMock = new();
+		Mock<IFileProvider> fileProviderMock = new();
+		Mock<IPathProvider> pathProviderMock = new();
+
+		PngConvertSettings settings = new()
+		{
+			SourceFolder = @"X:\Source",
+			TargetFolder = @"X:\Target"
+		};
+
+		directoryProviderMock.Setup(x => x.Exists(settings.SourceFolder)).Returns(true);
+		pathProviderMock.Setup(x => x.Combine(settings.SourceFolder, "Result.json")).Returns(@"X:\Source\Result.json");
+		fileProviderMock.Setup(x => x.Exists(@"X:\Source\Result.json")).Returns(false);
+		todoServiceMock.Setup(x => x.GetTodos(settings, ImageType.PNG)).Throws(new InvalidOperationException("boom"));
+
+		PngConvertCommand command = new(loggerMock.Object, todoServiceMock.Object, directoryProviderMock.Object, fileProviderMock.Object, pathProviderMock.Object);
+
+		int result = InvokeExecute(command, settings);
+
+		Assert.AreEqual(1, result);
+		loggerMock.Verify(x => x.Log(It.IsAny<Action<Microsoft.Extensions.Logging.ILogger, Exception?>>(), It.IsAny<Exception?>()), Times.Once);
+		todoServiceMock.Verify(x => x.GetTodos(settings, ImageType.PNG), Times.Once);
+		todoServiceMock.Verify(x => x.GetTodosDone(It.IsAny<TodoCollection>(), It.IsAny<ConvertSettingsBase>(), It.IsAny<ImageType>(), It.IsAny<bool>()), Times.Never);
+	}
+
 	private static int InvokeExecute(PngConvertCommand command, PngConvertSettings settings)
 	{
 		MethodInfo method = typeof(PngConvertCommand).GetMethod("Execute", BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -93,5 +123,4 @@ public sealed class PngConvertCommandTests
 		todos.Enqueue(new TodoModel("32.dds", string.Empty, @"X:\Source\32.dds", @"X:\Target", "HASH-1"));
 		return todos;
 	}
-
 }


### PR DESCRIPTION
**Changes:**

- Moved logging to `ConvertCommandBase` using `ILoggerService<TCommand>` to centralize and simplify logging across derived commands.
- Updated constructors and exception handling to leverage the new logging mechanism.
- Removed redundant logging code from `DdsConvertCommand` and `PngConvertCommand`.
- Updated test cases to mock `ILoggerService` and verify logging behavior.
- Added new tests to ensure exceptions are logged correctly.
- Cleaned up unused imports and improved code consistency in type usage.

closes #227 