### PR TITLE
feat: Refactor providers with source generation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BB84.Extensions" Version="4.3.520" />
+    <PackageVersion Include="BB84.SourceGenerators" Version="2.0.526" />
     <PackageVersion Include="BCnEncoder.Net" Version="2.3.0" />
     <PackageVersion Include="BCnEncoder.Net.ImageSharp" Version="1.1.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/DDS.Tools/Common/AssemblyInformation.cs
+++ b/src/DDS.Tools/Common/AssemblyInformation.cs
@@ -1,0 +1,7 @@
+﻿using BB84.SourceGenerators.Attributes;
+
+namespace DDS.Tools.Common;
+
+[GenerateAssemblyInformation]
+internal static partial class AssemblyInformation
+{ }

--- a/src/DDS.Tools/Common/AssemblyInformation.cs
+++ b/src/DDS.Tools/Common/AssemblyInformation.cs
@@ -1,4 +1,11 @@
-﻿using BB84.SourceGenerators.Attributes;
+﻿// -----------------------------------------------------------------------------
+// Copyright:	Robert Peter Meyer
+// License:		MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------------
+using BB84.SourceGenerators.Attributes;
 
 namespace DDS.Tools.Common;
 

--- a/src/DDS.Tools/DDS.Tools.csproj
+++ b/src/DDS.Tools/DDS.Tools.csproj
@@ -1,9 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
+		<EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="BB84.Extensions" />
+		<PackageReference Include="BB84.SourceGenerators">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="BCnEncoder.Net" />
 		<PackageReference Include="BCnEncoder.Net.ImageSharp" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" />

--- a/src/DDS.Tools/Interfaces/Providers/IDirectoryProvider.cs
+++ b/src/DDS.Tools/Interfaces/Providers/IDirectoryProvider.cs
@@ -5,21 +5,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
-using System.Diagnostics.CodeAnalysis;
-
 namespace DDS.Tools.Interfaces.Providers;
 
 /// <summary>
 /// The interface for the directory provider.
 /// </summary>
-public interface IDirectoryProvider
-{
-	/// <inheritdoc cref="Directory.CreateDirectory(string)"/>
-	DirectoryInfo CreateDirectory(string path);
-
-	/// <inheritdoc cref="Directory.Exists(string?)"/>
-	bool Exists([NotNullWhen(true)] string? path);
-
-	/// <inheritdoc cref="Directory.GetFiles(string, string, SearchOption)"/>
-	string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
-}
+public partial interface IDirectoryProvider
+{ }

--- a/src/DDS.Tools/Interfaces/Providers/IFileProvider.cs
+++ b/src/DDS.Tools/Interfaces/Providers/IFileProvider.cs
@@ -5,27 +5,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
-using System.Diagnostics.CodeAnalysis;
-
 namespace DDS.Tools.Interfaces.Providers;
 
 /// <summary>
 /// The interface for the file provider.
 /// </summary>
-public interface IFileProvider
-{
-	/// <inheritdoc cref="File.Copy(string, string)"/>
-	void Copy(string sourceFileName, string destFileName);
-
-	/// <inheritdoc cref="File.Exists(string?)"/>
-	bool Exists([NotNullWhen(true)] string? path);
-
-	/// <inheritdoc cref="File.Move(string, string)"/>
-	void Move(string sourceFileName, string destFileName);
-
-	/// <inheritdoc cref="File.ReadAllText(string)"/>
-	string ReadAllText(string path);
-
-	/// <inheritdoc cref="File.WriteAllText(string, string?)"/>
-	void WriteAllText(string path, string? contents);
-}
+public partial interface IFileProvider
+{ }

--- a/src/DDS.Tools/Interfaces/Providers/IPathProvider.cs
+++ b/src/DDS.Tools/Interfaces/Providers/IPathProvider.cs
@@ -10,11 +10,5 @@ namespace DDS.Tools.Interfaces.Providers;
 /// <summary>
 /// The interface for the path provider.
 /// </summary>
-public interface IPathProvider
-{
-	/// <inheritdoc cref="Path.Combine(string, string)"/>
-	string Combine(string path1, string path2);
-
-	/// <inheritdoc cref="Path.Combine(string, string, string)"/>
-	string Combine(string path1, string path2, string path3);
-}
+public partial interface IPathProvider
+{ }

--- a/src/DDS.Tools/Program.cs
+++ b/src/DDS.Tools/Program.cs
@@ -6,7 +6,6 @@
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 using DDS.Tools.Common;
 using DDS.Tools.Extensions;
@@ -19,12 +18,10 @@ using Spectre.Console.Cli;
 [ExcludeFromCodeCoverage(Justification = "Program startup class.")]
 internal sealed class Program
 {
-	private static readonly Assembly Assembly = typeof(Program).Assembly;
-
 	private static int Main(string[] args)
 	{
-		AnsiConsole.Write(new FigletText($"{Assembly.GetName().Name}"));
-		AnsiConsole.WriteLine($"{Assembly.GetName().Name} Command-line-interface {Assembly.GetName().Version}");
+		AnsiConsole.Write(new FigletText(AssemblyInformation.Title));
+		AnsiConsole.WriteLine($"{AssemblyInformation.Title} Command-line-interface {AssemblyInformation.Version}");
 		AnsiConsole.WriteLine();
 
 		IHostBuilder builder = Host.CreateDefaultBuilder(args)

--- a/src/DDS.Tools/Providers/DirectoryProvider.cs
+++ b/src/DDS.Tools/Providers/DirectoryProvider.cs
@@ -7,6 +7,8 @@
 // -----------------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
 
+using BB84.SourceGenerators.Attributes;
+
 using DDS.Tools.Interfaces.Providers;
 
 namespace DDS.Tools.Providers;
@@ -15,14 +17,6 @@ namespace DDS.Tools.Providers;
 /// The directory provider class.
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Wrapper class.")]
-internal sealed class DirectoryProvider : IDirectoryProvider
-{
-	public DirectoryInfo CreateDirectory(string path)
-		=> Directory.CreateDirectory(path);
-
-	public bool Exists([NotNullWhen(true)] string? path)
-		=> Directory.Exists(path);
-
-	public string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
-		=> Directory.GetFiles(path, searchPattern, searchOption);
-}
+[GenerateAbstraction(typeof(Directory), typeof(IDirectoryProvider), typeof(DirectoryProvider))]
+internal sealed partial class DirectoryProvider : IDirectoryProvider
+{ }

--- a/src/DDS.Tools/Providers/FileProvider.cs
+++ b/src/DDS.Tools/Providers/FileProvider.cs
@@ -7,6 +7,8 @@
 // -----------------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
 
+using BB84.SourceGenerators.Attributes;
+
 using DDS.Tools.Interfaces.Providers;
 
 namespace DDS.Tools.Providers;
@@ -15,20 +17,6 @@ namespace DDS.Tools.Providers;
 /// The file provider class.
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Wrapper class.")]
-internal sealed class FileProvider : IFileProvider
-{
-	public void Copy(string sourceFileName, string destFileName)
-		=> File.Copy(sourceFileName, destFileName);
-
-	public bool Exists([NotNullWhen(true)] string? path)
-		=> File.Exists(path);
-
-	public void Move(string sourceFileName, string destFileName)
-		=> File.Move(sourceFileName, destFileName);
-
-	public string ReadAllText(string path)
-		=> File.ReadAllText(path);
-
-	public void WriteAllText(string path, string? contents)
-		=> File.WriteAllText(path, contents);
-}
+[GenerateAbstraction(typeof(File), typeof(IFileProvider), typeof(FileProvider))]
+internal sealed partial class FileProvider : IFileProvider
+{ }

--- a/src/DDS.Tools/Providers/PathProvider.cs
+++ b/src/DDS.Tools/Providers/PathProvider.cs
@@ -7,6 +7,8 @@
 // -----------------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
 
+using BB84.SourceGenerators.Attributes;
+
 using DDS.Tools.Interfaces.Providers;
 
 namespace DDS.Tools.Providers;
@@ -15,11 +17,6 @@ namespace DDS.Tools.Providers;
 /// The path provider class.
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Wrapper class.")]
-internal sealed class PathProvider : IPathProvider
-{
-	public string Combine(string path1, string path2)
-		=> Path.Combine(path1, path2);
-
-	public string Combine(string path1, string path2, string path3)
-		=> Path.Combine(path1, path2, path3);
-}
+[GenerateAbstraction(typeof(Path), typeof(IPathProvider), typeof(PathProvider))]
+internal sealed partial class PathProvider : IPathProvider
+{ }


### PR DESCRIPTION
**Changes:**

- Replaced manual implementations of `DirectoryProvider`, `FileProvider`, and `PathProvider` with source-generated abstractions using the `BB84.SourceGenerators` package to reduce boilerplate code.
- Added `BB84.SourceGenerators` to the project and updated `DDS.Tools.csproj` to enable compiler-generated files.
- Refactored `IDirectoryProvider`, `IFileProvider`, and `IPathProvider` to be partial interfaces for source generation.
- Introduced `GenerateAssemblyInformation` in `AssemblyInformation.cs` to dynamically generate assembly metadata.
- Updated `Program.cs` to use the generated `AssemblyInformation` class, removing reflection-based code.
- Streamlined the codebase by removing redundant `using` directives and simplifying provider implementations.