### PR TITLE
refactor(services): extract duplicated dds/png target type mapping

### DIFF
--- a/src/DDS.Tools/Extensions/ImageTypeExtensions.cs
+++ b/src/DDS.Tools/Extensions/ImageTypeExtensions.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------------
+// Copyright:	Robert Peter Meyer
+// License:		MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------------
+using DDS.Tools.Enumerators;
+
+namespace DDS.Tools.Extensions;
+
+/// <summary>
+/// The image type extensions class.
+/// </summary>
+internal static class ImageTypeExtensions
+{
+	/// <summary>
+	/// Returns the image type the provided image type is converted into.
+	/// </summary>
+	/// <param name="imageType">The image type to get the counterpart for.</param>
+	/// <returns>The image type of the conversion target.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">If the image type is not supported.</exception>
+	internal static ImageType GetTargetType(this ImageType imageType)
+		=> imageType switch
+		{
+			ImageType.DDS => ImageType.PNG,
+			ImageType.PNG => ImageType.DDS,
+			_ => throw new ArgumentOutOfRangeException(nameof(imageType), imageType, null)
+		};
+}

--- a/src/DDS.Tools/Services/TodoPlanningService.cs
+++ b/src/DDS.Tools/Services/TodoPlanningService.cs
@@ -8,6 +8,7 @@
 using BB84.Extensions.Serialization;
 
 using DDS.Tools.Enumerators;
+using DDS.Tools.Extensions;
 using DDS.Tools.Interfaces.Models;
 using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Models;
@@ -78,10 +79,10 @@ internal sealed class TodoPlanningService(
 	private void MapTodoFromJson(TodoCollection todos, ConvertSettingsBase settings, ImageType imageType, TodoModel todoFromJson)
 	{
 		string newFullPathName = _pathProvider
-			.Combine(settings.TargetFolder, todoFromJson.RelativePath, todoFromJson.FileName.Replace(GetTargetFileExtensions(imageType), $"{imageType}"));
+			.Combine(settings.TargetFolder, todoFromJson.RelativePath, todoFromJson.FileName.Replace($"{imageType.GetTargetType()}", $"{imageType}"));
 
 		TodoModel todo = new(
-			fileName: $"{todoFromJson.FileHash}.{GetTargetFileExtensions(imageType)}",
+			fileName: $"{todoFromJson.FileHash}.{imageType.GetTargetType()}",
 			relativePath: todoFromJson.RelativePath,
 			fullPathName: newFullPathName,
 			targetFolder: settings.TargetFolder,
@@ -90,12 +91,4 @@ internal sealed class TodoPlanningService(
 
 		todos.Enqueue(todo);
 	}
-
-	private static string GetTargetFileExtensions(ImageType imageType)
-		=> imageType switch
-		{
-			ImageType.DDS => $"{ImageType.PNG}",
-			ImageType.PNG => $"{ImageType.DDS}",
-			_ => throw new ArgumentOutOfRangeException(nameof(imageType), imageType, null)
-		};
 }

--- a/src/DDS.Tools/Services/TodoTransformationService.cs
+++ b/src/DDS.Tools/Services/TodoTransformationService.cs
@@ -6,6 +6,7 @@
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
 using DDS.Tools.Enumerators;
+using DDS.Tools.Extensions;
 using DDS.Tools.Interfaces.Models;
 using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Models;
@@ -100,7 +101,7 @@ internal sealed class TodoTransformationService(
 
 		if (directoryInfo.Exists)
 		{
-			string newFileName = $"{GetTargetFileName(settings, todo)}.{GetTargetFileExtensions(imageType)}";
+			string newFileName = $"{GetTargetFileName(settings, todo)}.{imageType.GetTargetType()}";
 			string newFilePath = _pathProvider.Combine(targetFolder, newFileName);
 
 			image.Save(newFilePath, settings);
@@ -145,12 +146,4 @@ internal sealed class TodoTransformationService(
 
 		return todo.FileHash;
 	}
-
-	private static string GetTargetFileExtensions(ImageType imageType)
-		=> imageType switch
-		{
-			ImageType.DDS => $"{ImageType.PNG}",
-			ImageType.PNG => $"{ImageType.DDS}",
-			_ => throw new ArgumentOutOfRangeException(nameof(imageType), imageType, null)
-		};
 }


### PR DESCRIPTION
**Changes:**

- `GetTargetFileExtensions` existed verbatim in `TodoPlanningService` and `TodoTransformationService`.
- Adding a third format would have required editing both copies with nothing to catch a miss.
- Returns the enum instead of a pre-stringified value; callers interpolate, so the produced strings are unchanged.

closes #258 