### PR TITLE
refactor(naming): rename `Heigth` to `Height`

### DIFF
--- a/src/DDS.Tools/Interfaces/Models/IImageModel.cs
+++ b/src/DDS.Tools/Interfaces/Models/IImageModel.cs
@@ -25,9 +25,9 @@ public interface IImageModel
 	string Path { get; }
 
 	/// <summary>
-	/// The heigth of the image.
+	/// The height of the image.
 	/// </summary>
-	int Heigth { get; }
+	int Height { get; }
 
 	/// <summary>
 	/// The width of the image.

--- a/src/DDS.Tools/Models/Base/ImageModel.cs
+++ b/src/DDS.Tools/Models/Base/ImageModel.cs
@@ -20,7 +20,7 @@ internal abstract class ImageModel : IImageModel
 	/// <inheritdoc/>
 	public string Path { get; protected set; } = string.Empty;
 	/// <inheritdoc/>
-	public int Heigth { get; protected set; } = default;
+	public int Height { get; protected set; } = default;
 	/// <inheritdoc/>
 	public int Width { get; protected set; } = default;
 	/// <inheritdoc/>

--- a/src/DDS.Tools/Models/DdsImageModel.cs
+++ b/src/DDS.Tools/Models/DdsImageModel.cs
@@ -78,7 +78,7 @@ internal sealed class DdsImageModel(DdsDecoder decoder, ILoggerService<DdsImageM
 			Marshal.Copy(rgbaBytes, 0, _bitmap.GetPixels(), rgbaBytes.Length);
 
 			Width = width;
-			Heigth = height;
+			Height = height;
 
 			fileStream.Position = 0;
 			Data = fileStream.ToByteArray();

--- a/src/DDS.Tools/Models/PngImageModel.cs
+++ b/src/DDS.Tools/Models/PngImageModel.cs
@@ -75,7 +75,7 @@ internal sealed class PngImageModel(DdsEncoder encoder, ILoggerService<PngImageM
 			}
 
 			Width = _bitmap.Width;
-			Heigth = _bitmap.Height;
+			Height = _bitmap.Height;
 		}
 		catch (Exception ex)
 		{

--- a/src/DDS.Tools/Services/TodoTransformationService.cs
+++ b/src/DDS.Tools/Services/TodoTransformationService.cs
@@ -94,7 +94,7 @@ internal sealed class TodoTransformationService(
 		}
 		else if (settings.ConvertMode.Equals(ConvertModeType.Grouping))
 		{
-			newTargetFolder = _pathProvider.Combine(newTargetFolder, $"{image.Width}x{image.Heigth}");
+			newTargetFolder = _pathProvider.Combine(newTargetFolder, $"{image.Width}x{image.Height}");
 			return newTargetFolder;
 		}
 

--- a/tests/DDS.Tools.Tests/Models/DdsImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/DdsImageModelTests.cs
@@ -37,7 +37,7 @@ public class DdsImageModelTests : UnitTestBase
 		Assert.AreNotEqual(string.Empty, image.Name);
 		Assert.AreNotEqual(string.Empty, image.Path);
 		Assert.AreNotEqual(0, image.Width);
-		Assert.AreNotEqual(0, image.Heigth);
+		Assert.AreNotEqual(0, image.Height);
 		Assert.AreNotEqual([], image.Data);
 		Assert.AreNotEqual(string.Empty, image.Hash);
 	}

--- a/tests/DDS.Tools.Tests/Models/ImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/ImageModelTests.cs
@@ -21,7 +21,7 @@ public sealed class ImageModelTests
 
 		Assert.AreEqual(string.Empty, model.Name);
 		Assert.AreEqual(string.Empty, model.Path);
-		Assert.AreEqual(0, model.Heigth);
+		Assert.AreEqual(0, model.Height);
 		Assert.AreEqual(0, model.Width);
 		Assert.AreEqual(0, model.Data.Length);
 		Assert.AreEqual(string.Empty, model.Hash);
@@ -37,7 +37,7 @@ public sealed class ImageModelTests
 
 		Assert.AreEqual("32.png", model.Name);
 		Assert.AreEqual(@"X:\Target\32.dds", model.Path);
-		Assert.AreEqual(32, model.Heigth);
+		Assert.AreEqual(32, model.Height);
 		Assert.AreEqual(32, model.Width);
 		Assert.AreEqual(3, model.Data.Length);
 		Assert.AreEqual("HASH", model.Hash);
@@ -49,7 +49,7 @@ public sealed class ImageModelTests
 		{
 			Name = "32.png";
 			Path = filePath;
-			Heigth = 32;
+			Height = 32;
 			Width = 32;
 			Data = [1, 2, 3];
 			Hash = "HASH";

--- a/tests/DDS.Tools.Tests/Models/PngImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/PngImageModelTests.cs
@@ -37,7 +37,7 @@ public sealed class PngImageModelTests : UnitTestBase
 		Assert.AreNotEqual(string.Empty, image.Name);
 		Assert.AreNotEqual(string.Empty, image.Path);
 		Assert.AreNotEqual(0, image.Width);
-		Assert.AreNotEqual(0, image.Heigth);
+		Assert.AreNotEqual(0, image.Height);
 		Assert.AreNotEqual([], image.Data);
 		Assert.AreNotEqual(string.Empty, image.Hash);
 	}

--- a/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
@@ -123,7 +123,7 @@ public sealed class TodoServiceTests
 		PngConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
 
 		_imageModelMock.SetupGet(x => x.Width).Returns(64);
-		_imageModelMock.SetupGet(x => x.Heigth).Returns(32);
+		_imageModelMock.SetupGet(x => x.Height).Returns(32);
 
 		TodoCollection todos = new();
 		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH"));
@@ -147,7 +147,7 @@ public sealed class TodoServiceTests
 		PngConvertSettings settings = CreateSettings(ConvertModeType.Grouping);
 
 		_imageModelMock.SetupGet(x => x.Width).Returns(128);
-		_imageModelMock.SetupGet(x => x.Heigth).Returns(64);
+		_imageModelMock.SetupGet(x => x.Height).Returns(64);
 
 		TodoCollection todos = new();
 		todos.Enqueue(new TodoModel("x.DDS", string.Empty, Path.Combine(settings.SourceFolder, "x.DDS"), settings.TargetFolder, "DUP_HASH"));


### PR DESCRIPTION
**Changes:**

- The property was misspelled on `IImageModel`, on the `ImageModel` base, at every use, and in the doc comment, sitting next to a correctly spelled Width.
- `PngImageModel` read "Heigth = _bitmap.Height".
- Pure rename, no behavior change.
- `IImageModel` is public, but the project ships as an executable rather than a package, so nothing external binds to the old name.

closes #262 