### PR TITLE
refactor(style): fix editorconfig violations and name compression constants

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,7 +50,7 @@
 	</PropertyGroup>
 	<ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">
 		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
 	</ItemGroup>
 	<ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
 		<Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />

--- a/src/DDS.Tools/Commands/DdsConvertCommand.cs
+++ b/src/DDS.Tools/Commands/DdsConvertCommand.cs
@@ -37,5 +37,5 @@ internal sealed class DdsConvertCommand(
 
 	/// <inheritdoc/>
 	protected override int Execute([NotNull] CommandContext context, [NotNull] DdsConvertSettings settings, CancellationToken cancellationToken)
-	 => ExecuteCommand(settings, Type);
+		=> ExecuteCommand(settings, Type);
 }

--- a/src/DDS.Tools/Commands/PngConvertCommand.cs
+++ b/src/DDS.Tools/Commands/PngConvertCommand.cs
@@ -37,5 +37,5 @@ internal sealed class PngConvertCommand(
 
 	/// <inheritdoc/>
 	protected override int Execute([NotNull] CommandContext context, [NotNull] PngConvertSettings settings, CancellationToken cancellationToken)
-	 => ExecuteCommand(settings, Type);
+		=> ExecuteCommand(settings, Type);
 }

--- a/src/DDS.Tools/Models/DdsImageModel.cs
+++ b/src/DDS.Tools/Models/DdsImageModel.cs
@@ -33,6 +33,12 @@ namespace DDS.Tools.Models;
 /// <param name="logger">The logger service for logging operations and exceptions.</param>
 internal sealed class DdsImageModel(DdsDecoder decoder, ILoggerService<DdsImageModel> logger) : ImageModel, IImageModel
 {
+	/// <summary>The highest <see cref="PngCompressionLevel"/> value, the top of the input scale.</summary>
+	private const int MaxCompressionLevel = (int)PngCompressionLevel.BestCompression;
+
+	/// <summary>The highest SkiaSharp quality value, the top of the output scale.</summary>
+	private const int MaxSkiaQuality = 100;
+
 	private readonly DdsDecoder _ddsDecoder = decoder;
 	private readonly ILoggerService<DdsImageModel> _logger = logger;
 	private SKBitmap? _bitmap;
@@ -121,9 +127,9 @@ internal sealed class DdsImageModel(DdsDecoder decoder, ILoggerService<DdsImageM
 	}
 
 	/// <summary>
-	/// Maps a <see cref="PngCompressionLevel"/> value (0–9) to a SkiaSharp PNG quality value (0–100).
+	/// Maps a <see cref="PngCompressionLevel"/> value to a SkiaSharp PNG quality value.
 	/// SkiaSharp quality 100 means least compression; 0 means most compression.
 	/// </summary>
-	private static int MapCompressionLevelToQuality(PngCompressionLevel level) =>
-		(9 - (int)level) * 100 / 9;
+	private static int MapCompressionLevelToQuality(PngCompressionLevel level)
+		=> (MaxCompressionLevel - (int)level) * MaxSkiaQuality / MaxCompressionLevel;
 }

--- a/src/DDS.Tools/Settings/Base/ConvertSettingsBase.cs
+++ b/src/DDS.Tools/Settings/Base/ConvertSettingsBase.cs
@@ -29,7 +29,7 @@ public abstract class ConvertSettingsBase : CommandSettings
 	/// The target folder of the images.
 	/// </summary>
 	[Description(@"The target folder of the images.")]
-  [CommandArgument(1, "<TargetFolder>")]
+	[CommandArgument(1, "<TargetFolder>")]
 	public string TargetFolder { get; set; } = string.Empty;
 
 	/// <summary>

--- a/tests/DDS.Tools.Tests/Commands/Base/ConvertCommandBaseTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/Base/ConvertCommandBaseTests.cs
@@ -112,7 +112,7 @@ public sealed class ConvertCommandBaseTests
 		IDirectoryProvider directoryProvider,
 		IFileProvider fileProvider,
 		IPathProvider pathProvider)
-	 : ConvertCommandBase<DdsConvertSettings, DdsConvertCommand>(loggerService, todoService, directoryProvider, fileProvider, pathProvider)
+		: ConvertCommandBase<DdsConvertSettings, DdsConvertCommand>(loggerService, todoService, directoryProvider, fileProvider, pathProvider)
 	{
 		public int InvokeAction(ConvertSettingsBase settings, ImageType imageType)
 			=> Action(settings, imageType);

--- a/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
@@ -292,7 +292,7 @@ public sealed class TodoServiceTests
 	}
 
 	private TodoService CreateSut()
-	 => new(
+		=> new(
 			_loggerServiceMock.Object,
 			_directoryProviderMock.Object,
 			_fileProviderMock.Object,


### PR DESCRIPTION
**Changes:**

- Several lines were space indented against `indent_style = tab`, so editors honouring editorconfig wanted to reformat them on save and add noise to unrelated pull requests.
- Also names the two magic numbers in `MapCompressionLevelToQuality`.
- The 9 appeared twice and is really `PngCompressionLevel.BestCompression`, so it is now derived from the enum and cannot go stale if a level is added.

closes #263 