### PR TITLE
fix(encoders): stop the dds encoder leaking Bc3 across images

### DIFF
--- a/src/DDS.Tools/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DDS.Tools/Extensions/ServiceCollectionExtensions.cs
@@ -37,7 +37,8 @@ internal static class ServiceCollectionExtensions
 	{
 		services.RegisterLoggerService(environment);
 
-		services.AddSingleton<DdsEncoder>();
+		// The encoder carries per image output options, so it must not be shared.
+		services.AddTransient<DdsEncoder>();
 		services.AddSingleton<DdsDecoder>();
 		services.AddSingleton<ITodoService, TodoService>();
 

--- a/src/DDS.Tools/Models/PngImageModel.cs
+++ b/src/DDS.Tools/Models/PngImageModel.cs
@@ -97,8 +97,11 @@ internal sealed class PngImageModel(DdsEncoder encoder, ILoggerService<PngImageM
 			if (fileInfo.Exists)
 				throw new ArgumentException($"Already exists: '{filePath}'");
 
-			if (_bitmap is not null && HasTransparency(_bitmap))
-				_ddsEncoder.OutputOptions.Format = CompressionFormat.Bc3;
+			// Both options must be assigned on every save. Setting the format only for
+			// transparent images would leak it into every following image of the run.
+			_ddsEncoder.OutputOptions.Format = _bitmap is not null && HasTransparency(_bitmap)
+				? CompressionFormat.Bc3
+				: CompressionFormat.Bc1;
 
 			_ddsEncoder.OutputOptions.Quality = pngSettings.Compression;
 

--- a/tests/DDS.Tools.Tests/Models/PngImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/PngImageModelTests.cs
@@ -5,8 +5,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
+using System.Text;
+
 using DDS.Tools.Enumerators;
 using DDS.Tools.Interfaces.Models;
+using DDS.Tools.Interfaces.Services;
+using DDS.Tools.Models;
 using DDS.Tools.Settings;
 using DDS.Tools.Tests;
 
@@ -63,6 +67,59 @@ public sealed class PngImageModelTests : UnitTestBase
 		image.Save(NewFilePath, settings);
 
 		Assert.IsTrue(File.Exists(NewFilePath));
+	}
+
+	[TestMethod]
+	public void SaveDoesNotLeakCompressionFormatBetweenImages()
+	{
+		PngConvertSettings settings = new()
+		{
+			SourceFolder = TestConstants.PngResourcePath,
+			TargetFolder = TestConstants.ResourcePath,
+		};
+
+		// One encoder shared by both models, which is what the singleton registration produced.
+		DdsEncoder encoder = ServiceProvider.GetRequiredService<DdsEncoder>();
+		ILoggerService<PngImageModel> logger = ServiceProvider.GetRequiredService<ILoggerService<PngImageModel>>();
+
+		string transparentTarget = Path.Combine(TestConstants.ResourcePath, "leak_transparent.dds");
+		string opaqueTarget = Path.Combine(TestConstants.ResourcePath, "leak_opaque.dds");
+
+		try
+		{
+			PngImageModel transparent = new(encoder, logger);
+			transparent.Load(Path.Combine(TestConstants.PngResourcePath, "32A.png"));
+			transparent.Save(transparentTarget, settings);
+
+			PngImageModel opaque = new(encoder, logger);
+			opaque.Load(Path.Combine(TestConstants.PngResourcePath, "32.png"));
+			opaque.Save(opaqueTarget, settings);
+
+			Assert.AreEqual("DXT5", ReadFourCC(transparentTarget));
+			Assert.AreEqual("DXT1", ReadFourCC(opaqueTarget));
+		}
+		finally
+		{
+			File.Delete(transparentTarget);
+			File.Delete(opaqueTarget);
+		}
+	}
+
+	/// <summary>
+	/// Reads the four character code of the pixel format from a dds file header.
+	/// </summary>
+	private static string ReadFourCC(string filePath)
+	{
+		// 4 byte magic, then the pixel format four character code 80 bytes into the header.
+		const int fourCCOffset = 84;
+
+		using FileStream fileStream = File.OpenRead(filePath);
+		byte[] buffer = new byte[4];
+
+		fileStream.Position = fourCCOffset;
+		fileStream.ReadExactly(buffer);
+
+		return Encoding.ASCII.GetString(buffer);
 	}
 
 	[TestMethod]


### PR DESCRIPTION
**Changes:**

- Save set `OutputOptions.Format` to Bc3 for images with an alpha channel but never set it back, and the encoder was a singleton.
- The first transparent png therefore switched the whole run to Bc3, so every later texture was encoded in the wrong format, silently and at roughly twice the size it should have been.
- Assigns the format on every save rather than only in the transparent case, and registers the encoder as transient so instances are not shared at all.
- Adds a regression test that shares one encoder between two models and asserts the second output is DXT1.

closes #264 