### PR TITLE
fix(memory): dispose the native bitmap held by image models

### DIFF
--- a/src/DDS.Tools/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DDS.Tools/Extensions/ServiceCollectionExtensions.cs
@@ -46,11 +46,15 @@ internal static class ServiceCollectionExtensions
 		services.AddSingleton<IFileProvider, FileProvider>();
 		services.AddSingleton<IPathProvider, PathProvider>();
 
-		services.AddKeyedTransient<IImageModel, PngImageModel>(ImageType.PNG);
-		services.AddKeyedTransient<IImageModel, DdsImageModel>(ImageType.DDS);
-
-		services.AddSingleton<Func<ImageType, IImageModel>>(serviceProvider
-			=> imageType => serviceProvider.GetRequiredKeyedService<IImageModel>(imageType));
+		// Image models are disposable and created per file. Resolving them from the container
+		// would enroll every instance in the root scope's disposal tracking and keep the native
+		// image memory alive for the whole run, so they are activated with the caller owning them.
+		services.AddSingleton<Func<ImageType, IImageModel>>(serviceProvider => imageType => imageType switch
+		{
+			ImageType.PNG => ActivatorUtilities.CreateInstance<PngImageModel>(serviceProvider),
+			ImageType.DDS => ActivatorUtilities.CreateInstance<DdsImageModel>(serviceProvider),
+			_ => throw new ArgumentOutOfRangeException(nameof(imageType), imageType, null)
+		});
 
 		return services;
 	}

--- a/src/DDS.Tools/Interfaces/Models/IImageModel.cs
+++ b/src/DDS.Tools/Interfaces/Models/IImageModel.cs
@@ -12,7 +12,10 @@ namespace DDS.Tools.Interfaces.Models;
 /// <summary>
 /// The image file interface.
 /// </summary>
-public interface IImageModel
+/// <remarks>
+/// Implementations hold native image memory, so instances must be disposed once processed.
+/// </remarks>
+public interface IImageModel : IDisposable
 {
 	/// <summary>
 	/// The file name of the image.

--- a/src/DDS.Tools/Models/Base/ImageModel.cs
+++ b/src/DDS.Tools/Models/Base/ImageModel.cs
@@ -8,6 +8,8 @@
 using DDS.Tools.Interfaces.Models;
 using DDS.Tools.Settings.Base;
 
+using SkiaSharp;
+
 namespace DDS.Tools.Models.Base;
 
 /// <summary>
@@ -15,6 +17,11 @@ namespace DDS.Tools.Models.Base;
 /// </summary>
 internal abstract class ImageModel : IImageModel
 {
+	/// <summary>
+	/// The decoded image, backed by native memory that is released on <see cref="Dispose"/>.
+	/// </summary>
+	protected SKBitmap? Bitmap { get; set; }
+
 	/// <inheritdoc/>
 	public string Name { get; protected set; } = string.Empty;
 	/// <inheritdoc/>
@@ -33,4 +40,12 @@ internal abstract class ImageModel : IImageModel
 
 	/// <inheritdoc/>
 	public abstract void Save(string filePath, ConvertSettingsBase settings);
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		Bitmap?.Dispose();
+		Bitmap = null;
+		GC.SuppressFinalize(this);
+	}
 }

--- a/src/DDS.Tools/Models/DdsImageModel.cs
+++ b/src/DDS.Tools/Models/DdsImageModel.cs
@@ -41,7 +41,6 @@ internal sealed class DdsImageModel(DdsDecoder decoder, ILoggerService<DdsImageM
 
 	private readonly DdsDecoder _ddsDecoder = decoder;
 	private readonly ILoggerService<DdsImageModel> _logger = logger;
-	private SKBitmap? _bitmap;
 
 	private static readonly Action<ILogger, string, Exception?> LogExceptionWithParams =
 		LoggerMessage.Define<string>(LogLevel.Error, 0, "Exception occured. Params = {Parameters}");
@@ -80,8 +79,8 @@ internal sealed class DdsImageModel(DdsDecoder decoder, ILoggerService<DdsImageM
 			}
 
 			var info = new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-			_bitmap = new SKBitmap(info);
-			Marshal.Copy(rgbaBytes, 0, _bitmap.GetPixels(), rgbaBytes.Length);
+			Bitmap = new SKBitmap(info);
+			Marshal.Copy(rgbaBytes, 0, Bitmap.GetPixels(), rgbaBytes.Length);
 
 			Width = width;
 			Height = height;
@@ -115,7 +114,7 @@ internal sealed class DdsImageModel(DdsDecoder decoder, ILoggerService<DdsImageM
 			// Map PngCompressionLevel (0–9) to SkiaSharp PNG quality (100 = no compression, 0 = max compression).
 			int quality = MapCompressionLevelToQuality(ddsSettings.Compression);
 
-			using SKImage skImage = SKImage.FromBitmap(_bitmap);
+			using SKImage skImage = SKImage.FromBitmap(Bitmap);
 			using SKData encoded = skImage.Encode(SKEncodedImageFormat.Png, quality);
 			encoded.SaveTo(fileStream);
 		}

--- a/src/DDS.Tools/Models/PngImageModel.cs
+++ b/src/DDS.Tools/Models/PngImageModel.cs
@@ -36,7 +36,6 @@ internal sealed class PngImageModel(DdsEncoder encoder, ILoggerService<PngImageM
 {
 	private readonly DdsEncoder _ddsEncoder = encoder;
 	private readonly ILoggerService<PngImageModel> _logger = logger;
-	private SKBitmap? _bitmap;
 
 	private static readonly Action<ILogger, string, Exception?> LogExceptionWithParams =
 		LoggerMessage.Define<string>(LogLevel.Error, 0, "Exception occured. Params = {Parameters}");
@@ -66,16 +65,16 @@ internal sealed class PngImageModel(DdsEncoder encoder, ILoggerService<PngImageM
 			// Ensure the bitmap is in Rgba8888 format so BCnEncoder receives the expected byte layout.
 			if (decoded.ColorType != SKColorType.Rgba8888)
 			{
-				_bitmap = decoded.Copy(SKColorType.Rgba8888);
+				Bitmap = decoded.Copy(SKColorType.Rgba8888);
 				decoded.Dispose();
 			}
 			else
 			{
-				_bitmap = decoded;
+				Bitmap = decoded;
 			}
 
-			Width = _bitmap.Width;
-			Height = _bitmap.Height;
+			Width = Bitmap.Width;
+			Height = Bitmap.Height;
 		}
 		catch (Exception ex)
 		{
@@ -99,17 +98,17 @@ internal sealed class PngImageModel(DdsEncoder encoder, ILoggerService<PngImageM
 
 			// Both options must be assigned on every save. Setting the format only for
 			// transparent images would leak it into every following image of the run.
-			_ddsEncoder.OutputOptions.Format = _bitmap is not null && HasTransparency(_bitmap)
+			_ddsEncoder.OutputOptions.Format = Bitmap is not null && HasTransparency(Bitmap)
 				? CompressionFormat.Bc3
 				: CompressionFormat.Bc1;
 
 			_ddsEncoder.OutputOptions.Quality = pngSettings.Compression;
 
 			// Extract raw RGBA bytes from the bitmap and encode to DDS using BCnEncoder's raw API.
-			byte[] rgbaBytes = new byte[_bitmap!.ByteCount];
-			Marshal.Copy(_bitmap.GetPixels(), rgbaBytes, 0, rgbaBytes.Length);
+			byte[] rgbaBytes = new byte[Bitmap!.ByteCount];
+			Marshal.Copy(Bitmap.GetPixels(), rgbaBytes, 0, rgbaBytes.Length);
 
-			DdsFile ddsFile = _ddsEncoder.EncodeToDds(rgbaBytes, _bitmap.Width, _bitmap.Height, PixelFormat.Rgba32);
+			DdsFile ddsFile = _ddsEncoder.EncodeToDds(rgbaBytes, Bitmap.Width, Bitmap.Height, PixelFormat.Rgba32);
 			using FileStream fileStream = File.OpenWrite(filePath);
 			ddsFile.Write(fileStream);
 		}

--- a/src/DDS.Tools/Services/TodoPlanningService.cs
+++ b/src/DDS.Tools/Services/TodoPlanningService.cs
@@ -62,7 +62,7 @@ internal sealed class TodoPlanningService(
 	{
 		FileInfo fileInfo = new(file);
 
-		IImageModel image = _imageModelFactory(imageType);
+		using IImageModel image = _imageModelFactory(imageType);
 		image.Load(file);
 
 		TodoModel todo = new(

--- a/src/DDS.Tools/Services/TodoTransformationService.cs
+++ b/src/DDS.Tools/Services/TodoTransformationService.cs
@@ -60,7 +60,7 @@ internal sealed class TodoTransformationService(
 
 	private void TransferImage(ConvertSettingsBase settings, TodoModel todo, ImageType imageType)
 	{
-		IImageModel image = _imageModelFactory(imageType);
+		using IImageModel image = _imageModelFactory(imageType);
 		image.Load(todo.FullPathName);
 
 		string targetFolder = PrepareTargetFolder(settings, image, todo);

--- a/tests/DDS.Tools.Tests/Models/DdsImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/DdsImageModelTests.cs
@@ -30,7 +30,7 @@ public class DdsImageModelTests : UnitTestBase
 	[TestMethod]
 	public void LoadTest()
 	{
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.DDS);
+		using IImageModel image = CreateImageModel();
 
 		image.Load(FilePath);
 
@@ -45,7 +45,7 @@ public class DdsImageModelTests : UnitTestBase
 	[TestMethod]
 	public void LoadExceptionTest()
 	{
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.DDS);
+		using IImageModel image = CreateImageModel();
 		image?.Load(@"D:\");
 	}
 
@@ -57,7 +57,7 @@ public class DdsImageModelTests : UnitTestBase
 			SourceFolder = TestConstants.DdsResourcePath,
 			TargetFolder = TestConstants.ResourcePath,
 		};
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.DDS);
+		using IImageModel image = CreateImageModel();
 		image.Load(FilePath);
 
 		image.Save(NewFilePath, settings);
@@ -73,9 +73,12 @@ public class DdsImageModelTests : UnitTestBase
 			SourceFolder = TestConstants.DdsResourcePath,
 			TargetFolder = TestConstants.ResourcePath,
 		};
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.DDS);
+		using IImageModel image = CreateImageModel();
 		image.Load(FilePath);
 
 		image.Save(FilePath, settings);
 	}
+
+	private static IImageModel CreateImageModel()
+		=> ServiceProvider.GetRequiredService<Func<ImageType, IImageModel>>()(ImageType.DDS);
 }

--- a/tests/DDS.Tools.Tests/Models/ImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/ImageModelTests.cs
@@ -9,6 +9,8 @@ using DDS.Tools.Models.Base;
 using DDS.Tools.Settings;
 using DDS.Tools.Settings.Base;
 
+using SkiaSharp;
+
 namespace DDS.Tools.Tests.Models;
 
 [TestClass]
@@ -43,8 +45,35 @@ public sealed class ImageModelTests
 		Assert.AreEqual("HASH", model.Hash);
 	}
 
+	[TestMethod]
+	public void ImageModelDisposeReleasesBitmapTest()
+	{
+		TestImageModel model = new();
+		model.Load(@"X:\Source\32.png");
+
+		SKBitmap bitmap = model.LoadedBitmap!;
+		Assert.AreNotEqual(IntPtr.Zero, bitmap.Handle);
+
+		model.Dispose();
+
+		Assert.AreEqual(IntPtr.Zero, bitmap.Handle);
+		Assert.IsNull(model.LoadedBitmap);
+	}
+
+	[TestMethod]
+	public void ImageModelDisposeIsRepeatableTest()
+	{
+		TestImageModel model = new();
+		model.Load(@"X:\Source\32.png");
+
+		model.Dispose();
+		model.Dispose();
+	}
+
 	private sealed class TestImageModel : ImageModel
 	{
+		public SKBitmap? LoadedBitmap => Bitmap;
+
 		public override void Load(string filePath)
 		{
 			Name = "32.png";
@@ -53,6 +82,7 @@ public sealed class ImageModelTests
 			Width = 32;
 			Data = [1, 2, 3];
 			Hash = "HASH";
+			Bitmap = new SKBitmap(32, 32);
 		}
 
 		public override void Save(string filePath, ConvertSettingsBase settings)

--- a/tests/DDS.Tools.Tests/Models/PngImageModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/PngImageModelTests.cs
@@ -34,7 +34,7 @@ public sealed class PngImageModelTests : UnitTestBase
 	[TestMethod]
 	public void LoadTest()
 	{
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.PNG);
+		using IImageModel image = CreateImageModel();
 
 		image.Load(FilePath);
 
@@ -49,7 +49,7 @@ public sealed class PngImageModelTests : UnitTestBase
 	[TestMethod]
 	public void LoadExceptionTest()
 	{
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.PNG);
+		using IImageModel image = CreateImageModel();
 		image?.Load(@"D:\");
 	}
 
@@ -61,7 +61,7 @@ public sealed class PngImageModelTests : UnitTestBase
 			SourceFolder = TestConstants.PngResourcePath,
 			TargetFolder = TestConstants.ResourcePath,
 		};
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.PNG);
+		using IImageModel image = CreateImageModel();
 		image.Load(FilePath);
 
 		image.Save(NewFilePath, settings);
@@ -105,6 +105,9 @@ public sealed class PngImageModelTests : UnitTestBase
 		}
 	}
 
+	private static IImageModel CreateImageModel()
+		=> ServiceProvider.GetRequiredService<Func<ImageType, IImageModel>>()(ImageType.PNG);
+
 	/// <summary>
 	/// Reads the four character code of the pixel format from a dds file header.
 	/// </summary>
@@ -130,7 +133,7 @@ public sealed class PngImageModelTests : UnitTestBase
 			SourceFolder = TestConstants.PngResourcePath,
 			TargetFolder = TestConstants.ResourcePath,
 		};
-		IImageModel image = ServiceProvider.GetRequiredKeyedService<IImageModel>(ImageType.PNG);
+		using IImageModel image = CreateImageModel();
 		image.Load(FilePath);
 
 		image.Save(FilePath, settings);


### PR DESCRIPTION
**Changes:**

- Both models held an `SKBitmap` wrapping an unmanaged allocation and never released it, and one model is created per file, so a bulk run accumulated native memory for the whole process.
- Moves the bitmap onto the base class, makes `IImageModel` disposable and wraps both creation sites in using.
- The registration had to change with it: the models were keyed transients resolved from the root provider, and the container tracks every `IDisposable` it creates for the lifetime of the owning scope.
- Making them disposable while still resolving them that way would have rooted every bitmap in the container and made the leak worse.
- `ActivatorUtilities` constructs them without enrolling them in that tracking, so the caller owns them.
- Consumers already depend on the factory delegate, so no call site outside the registration changes shape.

closes #265 