### PR TITLE
fix(services): normalize the source folder before deriving the relative path

### DIFF
--- a/src/DDS.Tools/Services/TodoPlanningService.cs
+++ b/src/DDS.Tools/Services/TodoPlanningService.cs
@@ -40,8 +40,12 @@ internal sealed class TodoPlanningService(
 		if (files.Length.Equals(0))
 			return todos;
 
+		// The source folder may be relative or carry a trailing separator, while the file
+		// information always reports an absolute path, so normalize before relating the two.
+		string sourceFolder = _pathProvider.TrimEndingDirectorySeparator(_pathProvider.GetFullPath(settings.SourceFolder));
+
 		foreach (string file in files)
-			MapTodoFromFile(todos, settings, imageType, file);
+			MapTodoFromFile(todos, settings, sourceFolder, imageType, file);
 
 		return todos;
 	}
@@ -58,7 +62,7 @@ internal sealed class TodoPlanningService(
 		return todos;
 	}
 
-	private void MapTodoFromFile(TodoCollection todos, ConvertSettingsBase settings, ImageType imageType, string file)
+	private void MapTodoFromFile(TodoCollection todos, ConvertSettingsBase settings, string sourceFolder, ImageType imageType, string file)
 	{
 		FileInfo fileInfo = new(file);
 
@@ -67,7 +71,7 @@ internal sealed class TodoPlanningService(
 
 		TodoModel todo = new(
 			fileName: fileInfo.Name,
-			relativePath: $"{fileInfo.DirectoryName?.Replace(settings.SourceFolder, string.Empty)}",
+			relativePath: $"{fileInfo.DirectoryName?.Replace(sourceFolder, string.Empty, StringComparison.OrdinalIgnoreCase)}",
 			fullPathName: fileInfo.FullName,
 			targetFolder: settings.TargetFolder,
 			fileHash: image.Hash

--- a/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
@@ -74,6 +74,43 @@ public sealed class TodoServiceTests
 		_imageModelMock.Verify(x => x.Load(It.IsAny<string>()), Times.Exactly(2));
 	}
 
+	[DataTestMethod]
+	[DataRow("relative", DisplayName = "Relative source folder")]
+	[DataRow("trailing", DisplayName = "Trailing directory separator")]
+	[DataRow("casing", DisplayName = "Differing casing")]
+	public void GetTodosNormalizesSourceFolderForTheRelativePath(string variant)
+	{
+		ConfigureCommonMocks();
+
+		// Rooted below the current directory so the relative variant really is relative.
+		// GetRelativePath falls back to an absolute path when the two sit on different drives.
+		string rootPath = Path.Combine(Environment.CurrentDirectory, $"dds-tools-tests-{Guid.NewGuid():N}");
+		string sourceFolder = Path.Combine(rootPath, "source");
+
+		PngConvertSettings settings = new()
+		{
+			SourceFolder = variant switch
+			{
+				// A relative folder never matches the absolute directory of a discovered file.
+				"relative" => Path.GetRelativePath(Environment.CurrentDirectory, sourceFolder),
+				"trailing" => $"{sourceFolder}{Path.DirectorySeparatorChar}",
+				_ => sourceFolder.ToUpperInvariant()
+			},
+			TargetFolder = Path.Combine(rootPath, "target"),
+			ConvertMode = ConvertModeType.Manual
+		};
+
+		_directoryProviderMock
+			.Setup(x => x.GetFiles(settings.SourceFolder, "*.DDS", SearchOption.AllDirectories))
+			.Returns([Path.Combine(sourceFolder, "Blue", "64.DDS")]);
+
+		TodoService sut = CreateSut();
+
+		TodoCollection result = sut.GetTodos(settings, ImageType.DDS);
+
+		Assert.AreEqual($"{Path.DirectorySeparatorChar}Blue", result.Single().RelativePath);
+	}
+
 	[TestMethod]
 	public void GetTodosFromJsonReturnsMappedTodos()
 	{
@@ -312,6 +349,14 @@ public sealed class TodoServiceTests
 		_directoryProviderMock
 			.Setup(x => x.CreateDirectory(It.IsAny<string>()))
 			.Returns((string path) => Directory.CreateDirectory(path));
+
+		_pathProviderMock
+			.Setup(x => x.GetFullPath(It.IsAny<string>()))
+			.Returns((string path) => Path.GetFullPath(path));
+
+		_pathProviderMock
+			.Setup(x => x.TrimEndingDirectorySeparator(It.IsAny<string>()))
+			.Returns((string path) => Path.TrimEndingDirectorySeparator(path));
 	}
 
 	private static PngConvertSettings CreateSettings(ConvertModeType convertMode)


### PR DESCRIPTION
**Changes:**

- The relative path was derived by cutting `settings.SourceFolder` off the front of the file's absolute directory.
- When the two were not written identically the replace matched nothing and the todo silently carried the full absolute directory as its relative path.
- A relative source folder, a trailing separator, and a differing case all triggered it.
- With `--retain` the bad value was concatenated onto the target folder and `CreateDirectory` threw, aborting the run.
- Worse, the value is persisted to the result json, where `Path.Combine` discards everything before a rooted segment, so the round trip silently pointed back at the source tree.
- Normalizes once per run and compares case insensitively, which is the correct semantic for the `win-x64` target.

closes #273 