### PR TITLE
fix(service): report the number of transferred files as todos done

### DIFF
--- a/src/DDS.Tools/Services/TodoTransformationService.cs
+++ b/src/DDS.Tools/Services/TodoTransformationService.cs
@@ -36,27 +36,31 @@ internal sealed class TodoTransformationService(
 
 	internal TodoProcessingResult GetTodosDone(TodoCollection todos, ConvertSettingsBase settings, ImageType imageType)
 	{
-		HashSet<string> todosDone = [];
+		// The hash set only indexes what has been seen. Counting it would report distinct
+		// content rather than transferred files, which differ whenever a mode does not deduplicate.
+		HashSet<string> processedHashes = [];
+		int todosDoneCount = 0;
 		int todosDuplicateCount = 0;
 
 		foreach (TodoModel todo in todos)
-			GetTodoDone(todo, settings, imageType, todosDone, ref todosDuplicateCount);
-
-		return new(todosDone.Count, todosDuplicateCount);
-	}
-
-	private void GetTodoDone(TodoModel todo, ConvertSettingsBase settings, ImageType imageType, ISet<string> todosDone, ref int todosDuplicateCount)
-	{
-		if (DeduplicatesByHash(settings.ConvertMode) && todosDone.Contains(todo.FileHash))
 		{
-			AnsiConsole.MarkupLine($"[yellow]'{todo.FullPathName}' is a duplicate![/]");
-			todosDuplicateCount++;
-			return;
+			if (IsDuplicate(todo, settings, processedHashes))
+			{
+				AnsiConsole.MarkupLine($"[yellow]'{todo.FullPathName}' is a duplicate![/]");
+				todosDuplicateCount++;
+				continue;
+			}
+
+			TransferImage(settings, todo, imageType);
+			processedHashes.Add(todo.FileHash);
+			todosDoneCount++;
 		}
 
-		TransferImage(settings, todo, imageType);
-		todosDone.Add(todo.FileHash);
+		return new(todosDoneCount, todosDuplicateCount);
 	}
+
+	private static bool IsDuplicate(TodoModel todo, ConvertSettingsBase settings, ISet<string> processedHashes)
+		=> DeduplicatesByHash(settings.ConvertMode) && processedHashes.Contains(todo.FileHash);
 
 	private void TransferImage(ConvertSettingsBase settings, TodoModel todo, ImageType imageType)
 	{

--- a/tests/DDS.Tools.Tests/Services/TodoTransformationServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoTransformationServiceTests.cs
@@ -1,0 +1,111 @@
+// -----------------------------------------------------------------------------
+// Copyright:	Robert Peter Meyer
+// License:		MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------------
+using DDS.Tools.Enumerators;
+using DDS.Tools.Interfaces.Models;
+using DDS.Tools.Interfaces.Providers;
+using DDS.Tools.Models;
+using DDS.Tools.Services;
+using DDS.Tools.Settings;
+
+using Moq;
+
+namespace DDS.Tools.Tests.Services;
+
+[TestClass]
+public sealed class TodoTransformationServiceTests
+{
+	private readonly Mock<IDirectoryProvider> _directoryProviderMock = new();
+	private readonly Mock<IFileProvider> _fileProviderMock = new();
+	private readonly Mock<IImageModel> _imageModelMock = new();
+	private readonly Mock<IPathProvider> _pathProviderMock = new();
+
+	[TestMethod]
+	public void GetTodosDoneManualCountsEveryTransferredTodo()
+	{
+		ConfigureCommonMocks();
+		PngConvertSettings settings = CreateSettings(ConvertModeType.Manual);
+
+		TodoTransformationService sut = CreateSut();
+
+		TodoProcessingResult result = sut.GetTodosDone(CreateDuplicateTodos(settings), settings, ImageType.DDS);
+
+		// Manual does not deduplicate, so both todos are transferred and both are counted.
+		Assert.AreEqual(2, result.TodosDoneCount);
+		Assert.AreEqual(0, result.DuplicatesCount);
+	}
+
+	[DataTestMethod]
+	[DataRow(ConvertModeType.Automatic)]
+	[DataRow(ConvertModeType.Grouping)]
+	public void GetTodosDoneCountsDuplicatesSeparately(ConvertModeType convertMode)
+	{
+		ConfigureCommonMocks();
+		PngConvertSettings settings = CreateSettings(convertMode);
+
+		TodoTransformationService sut = CreateSut();
+
+		TodoProcessingResult result = sut.GetTodosDone(CreateDuplicateTodos(settings), settings, ImageType.DDS);
+
+		Assert.AreEqual(1, result.TodosDoneCount);
+		Assert.AreEqual(1, result.DuplicatesCount);
+	}
+
+	[TestMethod]
+	public void GetTodosDoneCountsAccountForEveryTodo()
+	{
+		ConfigureCommonMocks();
+		PngConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
+		TodoCollection todos = CreateDuplicateTodos(settings);
+		int todoCount = todos.Count;
+
+		TodoTransformationService sut = CreateSut();
+
+		TodoProcessingResult result = sut.GetTodosDone(todos, settings, ImageType.DDS);
+
+		Assert.AreEqual(todoCount, result.TodosDoneCount + result.DuplicatesCount);
+	}
+
+	private static TodoCollection CreateDuplicateTodos(PngConvertSettings settings)
+	{
+		TodoCollection todos = new();
+		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH"));
+		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH"));
+
+		return todos;
+	}
+
+	private TodoTransformationService CreateSut()
+		=> new(
+			_directoryProviderMock.Object,
+			_fileProviderMock.Object,
+			_pathProviderMock.Object,
+			_ => _imageModelMock.Object);
+
+	private void ConfigureCommonMocks()
+	{
+		_pathProviderMock
+			.Setup(x => x.Combine(It.IsAny<string>(), It.IsAny<string>()))
+			.Returns((string a, string b) => Path.Combine(a, b));
+
+		_directoryProviderMock
+			.Setup(x => x.CreateDirectory(It.IsAny<string>()))
+			.Returns((string path) => Directory.CreateDirectory(path));
+	}
+
+	private static PngConvertSettings CreateSettings(ConvertModeType convertMode)
+	{
+		string rootPath = Path.Combine(Path.GetTempPath(), $"dds-tools-tests-{Guid.NewGuid():N}");
+
+		return new PngConvertSettings
+		{
+			SourceFolder = Path.Combine(rootPath, "source"),
+			TargetFolder = Path.Combine(rootPath, "target"),
+			ConvertMode = convertMode
+		};
+	}
+}


### PR DESCRIPTION
**Changes:**

- One hash set served as both the duplicate index and the done counter, so the summary reported distinct content rather than files written.
- In `Manual` mode, which deliberately does not deduplicate, several files with identical content were all converted but counted once, leaving the run claiming fewer conversions than it made while also reporting zero duplicates.
- Gives the counter its own variable.
- `Automatic` and `Grouping` report exactly the same numbers as before, because there the two counts are equal by construction.
- Folding the per todo helper into the loop also drops both ref parameters.

closes #274 