### PR TITLE
feat(convert): add round-trip restore support, refactor options, upda…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ I needed some tools that were able to do some slight lifting so I can do some mo
 
 - Convert whole folders of textures between **DDS**, **PNG**, **TGA** and **JPEG** on a large scale
 - Source format is auto-detected from the folder, or set explicitly with `--from`
+- Folders may hold a **mix of formats** &mdash; every recognized file is converted in one pass
+- **Round-trip** support: `--restore` converts edited files back to each file's original format
 - Duplicate detection via a persisted result JSON file
 - Optional **retain structure** mode to preserve original folder and file names
 - Optional **separate by size** mode to sort textures into sub-folders by resolution
@@ -26,8 +28,7 @@ I needed some tools that were able to do some slight lifting so I can do some mo
 - Three convert modes: `Automatic`, `Manual`, and `Grouping`
 - Interactive CLI with progress spinner powered by [Spectre.Console](https://spectreconsole.net/)
 
-Image encoding and decoding is handled by [DirectXTex](https://github.com/microsoft/DirectXTex),
-so DDS.Tools is a **Windows-only** tool.
+Image encoding and decoding is handled by [DirectXTex](https://github.com/microsoft/DirectXTex), so DDS.Tools is a **Windows-only** tool.
 
 ## Usage
 
@@ -43,21 +44,22 @@ DDS.Tools convert <SourceFolder> <TargetFolder> [ConvertMode] --to <format> [opt
 
 ### Options
 
-| Option                | Description                                                          |
-| --------------------- | ------------------------------------------------------------------- |
-| `-f`, `--from`        | Source image format (`DDS`, `PNG`, `TGA`, `JPG`). Inferred from the folder if omitted |
-| `-t`, `--to`          | Target image format (`DDS`, `PNG`, `TGA`, `JPG`). Required          |
-| `-r`, `--retain`      | Retain original folder and file names                              |
-| `-b`, `--bysize`      | Separate converted textures into sub-folders by size               |
-| `-c`, `--compression` | Compression effort: `None`, `Fast`, `Balanced`, `Maximum`          |
+| Option                | Description                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `-f`, `--from`        | Source image format (`DDS`, `PNG`, `TGA`, `JPG`). Omit to convert every recognized format in the folder |
+| `-t`, `--to`          | Target image format (`DDS`, `PNG`, `TGA`, `JPG`). Required unless `--restore`                           |
+| `-r`, `--retain`      | Retain original folder and file names                                                                   |
+| `-b`, `--bysize`      | Separate converted textures into sub-folders by size                                                    |
+| `-c`, `--compression` | Compression effort: `None`, `Fast`, `Balanced`, `Maximum`                                               |
+| `-x`, `--restore`     | Restore files to the original format recorded in the source folder's `Result.json`                      |
 
 ### Convert Modes
 
-| Mode        | Description                         |
-| ----------- | ----------------------------------- |
-| `Automatic` | Default mode, options are ignored   |
-| `Manual`    | Manual mode                         |
-| `Grouping`  | Groups output by a defined criteria |
+| Mode        | Description                                                               |
+| ----------- | ------------------------------------------------------------------------- |
+| `Automatic` | Default mode, options are ignored. Writes `Result.json`                   |
+| `Manual`    | Honors `--retain` / `--bysize`. With `--retain` also writes `Result.json` |
+| `Grouping`  | Groups output by a defined criteria                                       |
 
 ### Examples
 
@@ -89,6 +91,21 @@ DDS.Tools convert "D:\PNG-Textures" "D:\DDS-Textures" --from PNG --to DDS --comp
 
 ```pwsh
 DDS.Tools convert "D:\TGA-Textures" "D:\DDS-Textures" --to DDS
+```
+
+#### Round-trip a folder that mixes TGA and JPG
+
+Convert every file to PNG for editing, keeping names and folders, then restore each
+file to its original format:
+
+```pwsh
+# forward: mixed formats -> PNG, Result.json records each file's original format
+DDS.Tools convert "D:\Game-Textures" "D:\Edit" Manual --to PNG --retain
+
+# ...edit the PNG files in place...
+
+# restore: PNG -> the original TGA / JPG formats and names
+DDS.Tools convert "D:\Edit" "D:\Game-Textures-New" Manual --retain --restore
 ```
 
 ## Contributing

--- a/src/DDS.Tools/Commands/ConvertCommand.cs
+++ b/src/DDS.Tools/Commands/ConvertCommand.cs
@@ -6,9 +6,7 @@
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
 using DDS.Tools.Common;
-using DDS.Tools.Enumerators;
 using DDS.Tools.Exceptions;
-using DDS.Tools.Extensions;
 using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Interfaces.Services;
 using DDS.Tools.Models;
@@ -67,13 +65,15 @@ internal sealed class ConvertCommand(
 		if (!_directoryProvider.Exists(settings.SourceFolder))
 			throw new CommandException($"Directory '{settings.SourceFolder}' not found.");
 
-		settings.From ??= InferSourceFormat(settings.SourceFolder);
-
 		// The result json is read from the source folder, but written to the target folder.
 		string jsonFilePath = _pathProvider.Combine(settings.SourceFolder, Constants.ResultFileName);
 		bool jsonExists = _fileProvider.Exists(jsonFilePath);
 
-		TodoCollection todos = jsonExists
+		if (settings.Restore && !jsonExists)
+			throw new CommandException($"No '{Constants.ResultFileName}' was found in '{settings.SourceFolder}' to restore from.");
+
+		// A stale result json is only consumed on an explicit restore run.
+		TodoCollection todos = settings.Restore
 			? _todoService.GetTodos(settings, _fileProvider.ReadAllText(jsonFilePath))
 			: _todoService.GetTodos(settings);
 
@@ -83,23 +83,7 @@ internal sealed class ConvertCommand(
 			return 1;
 		}
 
-		_todoService.GetTodosDone(todos, settings, jsonExists);
+		_todoService.GetTodosDone(todos, settings, settings.Restore);
 		return 0;
 	}
-
-	private ImageType InferSourceFormat(string sourceFolder)
-	{
-		ImageType[] present = [.. Enum.GetValues<ImageType>().Where(format => HasFilesOfFormat(sourceFolder, format))];
-
-		return present.Length switch
-		{
-			1 => present[0],
-			0 => throw new CommandException($"No convertible image files were found in '{sourceFolder}'."),
-			_ => throw new CommandException("The source folder holds more than one image format. Specify '--from'.")
-		};
-	}
-
-	private bool HasFilesOfFormat(string sourceFolder, ImageType format)
-		=> format.GetFileExtensions()
-			.Any(extension => _directoryProvider.GetFiles(sourceFolder, $"*.{extension}", SearchOption.AllDirectories).Length > 0);
 }

--- a/src/DDS.Tools/Extensions/ImageTypeExtensions.cs
+++ b/src/DDS.Tools/Extensions/ImageTypeExtensions.cs
@@ -12,8 +12,10 @@ namespace DDS.Tools.Extensions;
 /// <summary>
 /// The image type extensions class.
 /// </summary>
-internal static class ImageTypeExtensions
+internal static partial class ImageTypeExtensions
 {
+	private static readonly ImageType[] SupportedImageTypes = Enum.GetValues<ImageType>();
+
 	/// <summary>
 	/// Returns every file extension (without a leading dot) that identifies the
 	/// provided <paramref name="imageType"/> on disk.
@@ -40,4 +42,33 @@ internal static class ImageTypeExtensions
 	/// <exception cref="ArgumentOutOfRangeException">If the image type is not supported.</exception>
 	internal static string GetPrimaryExtension(this ImageType imageType)
 		=> imageType.GetFileExtensions()[0];
+
+	/// <summary>
+	/// Resolves the <see cref="ImageType"/> that owns the provided file extension or
+	/// file name, mirroring <see cref="GetFileExtensions(ImageType)"/>.
+	/// </summary>
+	/// <param name="extensionOrFileName">A file extension (with or without a leading dot) or a file name.</param>
+	/// <param name="imageType">The resolved image type when the lookup succeeds.</param>
+	/// <returns><see langword="true"/> when the extension maps to a known image type.</returns>
+	internal static bool TryGetImageType(string extensionOrFileName, out ImageType imageType)
+	{
+		string extension = Path.GetExtension(extensionOrFileName);
+
+		if (extension.Length.Equals(0))
+			extension = extensionOrFileName;
+
+		extension = extension.TrimStart('.').ToLowerInvariant();
+
+		foreach (ImageType candidate in SupportedImageTypes)
+		{
+			if (candidate.GetFileExtensions().Contains(extension))
+			{
+				imageType = candidate;
+				return true;
+			}
+		}
+
+		imageType = default;
+		return false;
+	}
 }

--- a/src/DDS.Tools/Models/TodoModel.cs
+++ b/src/DDS.Tools/Models/TodoModel.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright:	Robert Peter Meyer
 // License:		MIT
 //
@@ -7,6 +7,8 @@
 // -----------------------------------------------------------------------------
 using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
+
+using DDS.Tools.Enumerators;
 
 namespace DDS.Tools.Models;
 
@@ -18,12 +20,22 @@ namespace DDS.Tools.Models;
 /// <param name="fullPathName">The full path and file name of the image.</param>
 /// <param name="targetFolder">The target path of the image file.</param>
 /// <param name="fileHash">The md5 hash of the image file.</param>
-public sealed class TodoModel(string fileName, string relativePath, string fullPathName, string targetFolder, string fileHash)
+/// <param name="sourceType">The image format of the file to decode.</param>
+/// <param name="originalName">The original file name including its extension.</param>
+public sealed class TodoModel(
+	string fileName,
+	string relativePath,
+	string fullPathName,
+	string targetFolder,
+	string fileHash,
+	ImageType sourceType,
+	string originalName)
 {
 	/// <summary>
-	/// The name of the image file.
+	/// The name of the image file. Holds the original name until the transformation
+	/// records the name that was actually written.
 	/// </summary>
-	public string FileName { get; } = fileName;
+	public string FileName { get; internal set; } = fileName;
 
 	/// <summary>
 	/// The relative path of the image file.
@@ -46,6 +58,25 @@ public sealed class TodoModel(string fileName, string relativePath, string fullP
 	/// The md5 hash of the image file.
 	/// </summary>
 	public string FileHash { get; } = fileHash;
+
+	/// <summary>
+	/// The image format of the file located at <see cref="FullPathName"/>, used to
+	/// pick the decoder.
+	/// </summary>
+	[JsonConverter(typeof(JsonStringEnumConverter))]
+	public ImageType SourceType { get; } = sourceType;
+
+	/// <summary>
+	/// The original file name including its extension.
+	/// </summary>
+	public string OriginalName { get; } = originalName;
+
+	/// <summary>
+	/// The explicit per-file encode target. Only set on the restore path; a
+	/// <see langword="null"/> value means the target format comes from the settings.
+	/// </summary>
+	[JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+	public ImageType? TargetType { get; set; }
 }
 
 /// <summary>

--- a/src/DDS.Tools/Services/TodoPersistenceService.cs
+++ b/src/DDS.Tools/Services/TodoPersistenceService.cs
@@ -29,7 +29,7 @@ internal sealed class TodoPersistenceService(IFileProvider fileProvider, IPathPr
 
 	internal void PersistResult(TodoCollection todos, ConvertSettings settings, bool jsonExists, TodoProcessingResult result)
 	{
-		if (!jsonExists && settings.ConvertMode.Equals(ConvertModeType.Automatic))
+		if (!jsonExists && !settings.Restore && WritesResultJson(settings))
 		{
 			string jsonContent = todos.ToJson();
 			string jsonFilePath = _pathProvider.Combine(settings.TargetFolder, Constants.ResultFileName);
@@ -39,4 +39,10 @@ internal sealed class TodoPersistenceService(IFileProvider fileProvider, IPathPr
 		AnsiConsole.MarkupLine($"[green]Todos done:\t{result.TodosDoneCount}[/]");
 		AnsiConsole.MarkupLine($"[yellow]Duplicates:\t{result.DuplicatesCount}[/]");
 	}
+
+	// The result json is the cross-run dedup and restore ledger. It is written by the
+	// automatic mode and by the name-preserving manual mode ('--retain').
+	private static bool WritesResultJson(ConvertSettings settings)
+		=> settings.ConvertMode.Equals(ConvertModeType.Automatic)
+			|| (settings.ConvertMode.Equals(ConvertModeType.Manual) && settings.RetainStructure);
 }

--- a/src/DDS.Tools/Services/TodoPlanningService.cs
+++ b/src/DDS.Tools/Services/TodoPlanningService.cs
@@ -8,6 +8,8 @@
 using BB84.Extensions;
 using BB84.Extensions.Serialization;
 
+using DDS.Tools.Enumerators;
+using DDS.Tools.Exceptions;
 using DDS.Tools.Extensions;
 using DDS.Tools.Interfaces.Providers;
 using DDS.Tools.Models;
@@ -34,20 +36,26 @@ internal sealed class TodoPlanningService(
 	{
 		TodoCollection todos = [];
 
-		string[] files = settings.SourceFormat.GetFileExtensions()
-			.SelectMany(extension => _directoryProvider.GetFiles(settings.SourceFolder, $"*.{extension}", SearchOption.AllDirectories))
-			.Distinct()
-			.ToArray();
-
-		if (files.Length.Equals(0))
-			return todos;
+		// When '--from' is omitted every known format is scanned, so a folder may hold a
+		// mix of formats; an explicit '--from' restricts the run to that single format.
+		IEnumerable<ImageType> formats = settings.From is not null
+			? [settings.From.Value]
+			: Enum.GetValues<ImageType>();
 
 		// The source folder may be relative or carry a trailing separator, while the file
 		// information always reports an absolute path, so normalize before relating the two.
 		string sourceFolder = _pathProvider.TrimEndingDirectorySeparator(_pathProvider.GetFullPath(settings.SourceFolder));
 
-		foreach (string file in files)
-			MapTodoFromFile(todos, settings, sourceFolder, file);
+		foreach (ImageType format in formats)
+		{
+			string[] files = format.GetFileExtensions()
+				.SelectMany(extension => _directoryProvider.GetFiles(settings.SourceFolder, $"*.{extension}", SearchOption.AllDirectories))
+				.Distinct()
+				.ToArray();
+
+			foreach (string file in files)
+				MapTodoFromFile(todos, settings, sourceFolder, file, format);
+		}
 
 		return todos;
 	}
@@ -64,7 +72,7 @@ internal sealed class TodoPlanningService(
 		return todos;
 	}
 
-	private void MapTodoFromFile(TodoCollection todos, ConvertSettings settings, string sourceFolder, string file)
+	private void MapTodoFromFile(TodoCollection todos, ConvertSettings settings, string sourceFolder, string file, ImageType sourceType)
 	{
 		FileInfo fileInfo = new(file);
 
@@ -73,7 +81,9 @@ internal sealed class TodoPlanningService(
 			relativePath: $"{fileInfo.DirectoryName?.Replace(sourceFolder, string.Empty, StringComparison.OrdinalIgnoreCase)}",
 			fullPathName: fileInfo.FullName,
 			targetFolder: settings.TargetFolder,
-			fileHash: _fileProvider.ReadAllBytes(file).GetMD5String()
+			fileHash: _fileProvider.ReadAllBytes(file).GetMD5String(),
+			sourceType: sourceType,
+			originalName: fileInfo.Name
 			);
 
 		todos.Enqueue(todo);
@@ -81,16 +91,33 @@ internal sealed class TodoPlanningService(
 
 	private void MapTodoFromJson(TodoCollection todos, ConvertSettings settings, TodoModel todoFromJson)
 	{
-		string newFullPathName = _pathProvider
-			.Combine(settings.TargetFolder, todoFromJson.RelativePath, todoFromJson.FileName.Replace($"{settings.To}", $"{settings.SourceFormat}"));
+		if (!Enum.IsDefined(todoFromJson.SourceType))
+			throw new CommandException($"The result json entry '{todoFromJson.FileName}' has no original image format to restore to.");
+
+		string originalName = string.IsNullOrEmpty(todoFromJson.OriginalName)
+			? todoFromJson.FileName
+			: todoFromJson.OriginalName;
+
+		if (!ImageTypeExtensions.TryGetImageType(todoFromJson.FileName, out ImageType decodeType))
+			throw new CommandException($"The result json entry '{todoFromJson.FileName}' does not carry a known image extension.");
+
+		// The relative path carries a leading separator (or is empty), so it is concatenated
+		// rather than combined, matching how the transformation rebuilds retained folders.
+		string fullPathName = _pathProvider
+			.Combine($"{settings.SourceFolder}{todoFromJson.RelativePath}", todoFromJson.FileName);
 
 		TodoModel todo = new(
-			fileName: $"{todoFromJson.FileHash}.{settings.To}",
+			fileName: originalName,
 			relativePath: todoFromJson.RelativePath,
-			fullPathName: newFullPathName,
+			fullPathName: fullPathName,
 			targetFolder: settings.TargetFolder,
-			fileHash: todoFromJson.FileHash
-			);
+			fileHash: todoFromJson.FileHash,
+			sourceType: decodeType,
+			originalName: originalName
+			)
+		{
+			TargetType = todoFromJson.SourceType
+		};
 
 		todos.Enqueue(todo);
 	}

--- a/src/DDS.Tools/Services/TodoTransformationService.cs
+++ b/src/DDS.Tools/Services/TodoTransformationService.cs
@@ -6,7 +6,6 @@
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
 using DDS.Tools.Enumerators;
-using DDS.Tools.Extensions;
 using DDS.Tools.Imaging;
 using DDS.Tools.Interfaces.Imaging;
 using DDS.Tools.Interfaces.Providers;
@@ -61,12 +60,15 @@ internal sealed class TodoTransformationService(
 	}
 
 	private static bool IsDuplicate(TodoModel todo, ConvertSettings settings, ISet<string> processedHashes)
-		=> DeduplicatesByHash(settings.ConvertMode) && processedHashes.Contains(todo.FileHash);
+		=> !settings.Restore && DeduplicatesByHash(settings.ConvertMode) && processedHashes.Contains(todo.FileHash);
 
 	private void TransferImage(ConvertSettings settings, TodoModel todo)
 	{
+		// On a restore run the target format travels per file; otherwise it is the setting.
+		ImageType targetFormat = todo.TargetType ?? settings.To;
+
 		ImageCanvas canvas = _codecRegistry
-			.GetDecoder(settings.SourceFormat)
+			.GetDecoder(todo.SourceType)
 			.Decode(_fileProvider.ReadAllBytes(todo.FullPathName));
 
 		string targetFolder = PrepareTargetFolder(settings, canvas, todo);
@@ -77,14 +79,17 @@ internal sealed class TodoTransformationService(
 		string newFileName = GetTargetFileName(settings, todo);
 
 		// The grouping mode copies the source untouched, every other mode re-encodes.
-		if (settings.ConvertMode.Equals(ConvertModeType.Grouping))
+		if (settings.ConvertMode.Equals(ConvertModeType.Grouping) && !settings.Restore)
 		{
 			_fileProvider.Copy(todo.FullPathName, _pathProvider.Combine(targetFolder, newFileName));
+			todo.FileName = newFileName;
 			return;
 		}
 
-		byte[] encoded = _codecRegistry.GetEncoder(settings.To).Encode(canvas, settings.Compression);
-		_fileProvider.WriteAllBytes(_pathProvider.Combine(targetFolder, $"{newFileName}.{settings.To}"), encoded);
+		byte[] encoded = _codecRegistry.GetEncoder(targetFormat).Encode(canvas, settings.Compression);
+		string writtenName = $"{newFileName}.{targetFormat}";
+		_fileProvider.WriteAllBytes(_pathProvider.Combine(targetFolder, writtenName), encoded);
+		todo.FileName = writtenName;
 	}
 
 	private static bool DeduplicatesByHash(ConvertModeType convertMode)
@@ -93,6 +98,10 @@ internal sealed class TodoTransformationService(
 	private string PrepareTargetFolder(ConvertSettings settings, ImageCanvas canvas, TodoModel todo)
 	{
 		string newTargetFolder = todo.TargetFolder;
+
+		// A restore run always rebuilds the recorded folder tree.
+		if (settings.Restore)
+			return $"{newTargetFolder}{todo.RelativePath}";
 
 		if (settings.ConvertMode.Equals(ConvertModeType.Automatic))
 		{
@@ -116,6 +125,9 @@ internal sealed class TodoTransformationService(
 
 	private static string GetTargetFileName(ConvertSettings settings, TodoModel todo)
 	{
+		if (settings.Restore)
+			return Path.GetFileNameWithoutExtension(todo.OriginalName);
+
 		if (settings.ConvertMode == ConvertModeType.Manual && settings.RetainStructure)
 		{
 			FileInfo info = new(todo.FullPathName);

--- a/src/DDS.Tools/Settings/ConvertSettings.cs
+++ b/src/DDS.Tools/Settings/ConvertSettings.cs
@@ -8,7 +8,6 @@
 using System.ComponentModel;
 
 using DDS.Tools.Enumerators;
-using DDS.Tools.Exceptions;
 
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -80,18 +79,21 @@ public sealed class ConvertSettings : CommandSettings
 	public CompressionLevel Compression { get; set; } = CompressionLevel.Balanced;
 
 	/// <summary>
-	/// The resolved source format. Only valid once <see cref="From"/> has been set,
-	/// either from the command line or by inference.
+	/// Restore edited files back to the original format recorded in the source
+	/// folder's <c>Result.json</c>.
 	/// </summary>
-	/// <exception cref="CommandException">If the source format is still unknown.</exception>
-	internal ImageType SourceFormat
-		=> From ?? throw new CommandException("The source image format could not be determined.");
+	[Description("Restore files to the original format recorded in the source folder's Result.json.")]
+	[CommandOption("-x|--restore")]
+	public bool Restore { get; set; }
 
 	/// <inheritdoc/>
 	public override ValidationResult Validate()
 	{
-		if (!Enum.IsDefined(To))
+		if (!Restore && !Enum.IsDefined(To))
 			return ValidationResult.Error("The target format '--to' is required.");
+
+		if (Restore && From is not null)
+			return ValidationResult.Error("The '--from' option cannot be combined with '--restore'.");
 
 		if (From is not null && From.Value.Equals(To))
 			return ValidationResult.Error("The source and target format must differ.");

--- a/tests/DDS.Tools.Tests/Commands/CommandArgumentParsingTests.cs
+++ b/tests/DDS.Tools.Tests/Commands/CommandArgumentParsingTests.cs
@@ -58,6 +58,29 @@ public sealed class CommandArgumentParsingTests
 	}
 
 	[TestMethod]
+	public void ConvertSettingsBindRestoreFlagAndAllowMissingTargetFormat()
+	{
+		ProbeCommand.LastSettings = null;
+		CommandApp app = CreateApp();
+
+		int result = app.Run(["convert-probe", "src", "tgt", "--restore"]);
+
+		Assert.AreEqual(0, result);
+		Assert.IsNotNull(ProbeCommand.LastSettings);
+		Assert.IsTrue(ProbeCommand.LastSettings.Restore);
+	}
+
+	[TestMethod]
+	public void ConvertSettingsRejectRestoreCombinedWithFrom()
+	{
+		CommandApp app = CreateApp();
+
+		int result = app.Run(["convert-probe", "src", "tgt", "--restore", "--from", "PNG"]);
+
+		Assert.AreNotEqual(0, result);
+	}
+
+	[TestMethod]
 	public void ConvertSettingsRejectEqualSourceAndTargetFormat()
 	{
 		CommandApp app = CreateApp();

--- a/tests/DDS.Tools.Tests/Models/TodoCollectionTests.cs
+++ b/tests/DDS.Tools.Tests/Models/TodoCollectionTests.cs
@@ -5,6 +5,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
+using DDS.Tools.Enumerators;
 using DDS.Tools.Models;
 
 namespace DDS.Tools.Tests.Models;
@@ -16,8 +17,8 @@ public sealed class TodoCollectionTests
 	public void TodoCollectionQueueBehaviorTest()
 	{
 		TodoCollection todos = [];
-		TodoModel first = new("first.dds", "A", @"X:\A\first.dds", @"X:\Target", "HASH-1");
-		TodoModel second = new("second.dds", "B", @"X:\B\second.dds", @"X:\Target", "HASH-2");
+		TodoModel first = new("first.dds", "A", @"X:\A\first.dds", @"X:\Target", "HASH-1", ImageType.DDS, "first.dds");
+		TodoModel second = new("second.dds", "B", @"X:\B\second.dds", @"X:\Target", "HASH-2", ImageType.DDS, "second.dds");
 
 		todos.Enqueue(first);
 		todos.Enqueue(second);

--- a/tests/DDS.Tools.Tests/Models/TodoModelTests.cs
+++ b/tests/DDS.Tools.Tests/Models/TodoModelTests.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright:	Robert Peter Meyer
 // License:		MIT
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
+using DDS.Tools.Enumerators;
 using DDS.Tools.Models;
 
 namespace DDS.Tools.Tests.Models;
@@ -15,7 +16,7 @@ public sealed class TodoModelTests
 	[TestMethod]
 	public void TodoModelValuesTest()
 	{
-		TodoModel todo = new("32.dds", "Blue", @"X:\Source\Blue\32.dds", @"X:\Target", "HASH");
+		TodoModel todo = new("32.dds", "Blue", @"X:\Source\Blue\32.dds", @"X:\Target", "HASH", ImageType.DDS, "32.dds");
 
 		Assert.IsNotNull(todo);
 		Assert.AreEqual("32.dds", todo.FileName);
@@ -23,5 +24,8 @@ public sealed class TodoModelTests
 		Assert.AreEqual(@"X:\Source\Blue\32.dds", todo.FullPathName);
 		Assert.AreEqual(@"X:\Target", todo.TargetFolder);
 		Assert.AreEqual("HASH", todo.FileHash);
+		Assert.AreEqual(ImageType.DDS, todo.SourceType);
+		Assert.AreEqual("32.dds", todo.OriginalName);
+		Assert.IsNull(todo.TargetType);
 	}
 }

--- a/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoServiceTests.cs
@@ -75,6 +75,30 @@ public sealed class TodoServiceTests
 	}
 
 	[TestMethod]
+	public void GetTodosWithoutFromDiscoversEveryFormatAndTagsEachTodo()
+	{
+		ConfigureCommonMocks();
+		ConvertSettings settings = CreateSettings(ConvertModeType.Manual);
+		settings.From = null;
+		settings.RetainStructure = true;
+
+		_directoryProviderMock
+			.Setup(x => x.GetFiles(settings.SourceFolder, "*.tga", SearchOption.AllDirectories))
+			.Returns([Path.Combine(settings.SourceFolder, "32.tga")]);
+		_directoryProviderMock
+			.Setup(x => x.GetFiles(settings.SourceFolder, "*.jpg", SearchOption.AllDirectories))
+			.Returns([Path.Combine(settings.SourceFolder, "32.jpg")]);
+
+		TodoService sut = CreateSut();
+
+		TodoCollection result = sut.GetTodos(settings);
+
+		Assert.HasCount(2, result);
+		Assert.IsTrue(result.Any(todo => todo.SourceType == ImageType.TGA && todo.OriginalName == "32.tga"));
+		Assert.IsTrue(result.Any(todo => todo.SourceType == ImageType.JPG && todo.OriginalName == "32.jpg"));
+	}
+
+	[TestMethod]
 	[DataRow("relative", DisplayName = "Relative source folder")]
 	[DataRow("trailing", DisplayName = "Trailing directory separator")]
 	[DataRow("casing", DisplayName = "Differing casing")]
@@ -111,17 +135,21 @@ public sealed class TodoServiceTests
 	}
 
 	[TestMethod]
-	public void GetTodosFromJsonReturnsMappedTodos()
+	public void GetTodosFromJsonMapsLedgerEntriesBackToTheirOriginalFormat()
 	{
 		ConfigureCommonMocks();
-		ConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
+		ConvertSettings settings = CreateSettings(ConvertModeType.Manual);
+		settings.From = null;
+		settings.Restore = true;
 
 		string jsonContent = """
 			[
 				{
-					"fileName":"image.PNG",
-					"relativePath":"sub",
-					"fileHash":"ABC123"
+					"fileName":"64.PNG",
+					"relativePath":"\\Blue",
+					"fileHash":"ABC123",
+					"sourceType":"TGA",
+					"originalName":"64.tga"
 				}
 			]
 			""";
@@ -130,12 +158,34 @@ public sealed class TodoServiceTests
 
 		TodoCollection result = sut.GetTodos(settings, jsonContent);
 
-		Assert.HasCount(1, result);
-
 		TodoModel todo = result.Single();
-		Assert.AreEqual("ABC123.PNG", todo.FileName);
-		Assert.AreEqual("sub", todo.RelativePath);
-		Assert.AreEqual(Path.Combine(settings.TargetFolder, "sub", "image.DDS"), todo.FullPathName);
+		Assert.AreEqual("64.tga", todo.FileName);
+		Assert.AreEqual("64.tga", todo.OriginalName);
+		Assert.AreEqual(ImageType.PNG, todo.SourceType);
+		Assert.AreEqual(ImageType.TGA, todo.TargetType);
+		Assert.AreEqual(Path.Combine($"{settings.SourceFolder}\\Blue", "64.PNG"), todo.FullPathName);
+	}
+
+	[TestMethod]
+	public void GetTodosFromJsonWithoutOriginalFormatThrowsServiceExceptionAndLogs()
+	{
+		ConfigureCommonMocks();
+		ConvertSettings settings = CreateSettings(ConvertModeType.Manual);
+		settings.Restore = true;
+
+		string jsonContent = """
+			[
+				{ "fileName":"64.PNG", "relativePath":"", "fileHash":"ABC123" }
+			]
+			""";
+
+		TodoService sut = CreateSut();
+
+		Assert.Throws<ServiceException>(() => sut.GetTodos(settings, jsonContent));
+
+		_loggerServiceMock.Verify(
+			x => x.Log(It.IsAny<Action<ILogger, Exception?>>(), It.IsAny<Exception?>()),
+			Times.Once);
 	}
 
 	[TestMethod]
@@ -160,8 +210,8 @@ public sealed class TodoServiceTests
 		ConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
 
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH"));
-		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH"));
+		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "a.DDS"));
+		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "b.DDS"));
 
 		TodoService sut = CreateSut();
 
@@ -183,8 +233,8 @@ public sealed class TodoServiceTests
 		ConvertSettings settings = CreateSettings(ConvertModeType.Grouping);
 
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("x.DDS", string.Empty, Path.Combine(settings.SourceFolder, "x.DDS"), settings.TargetFolder, "DUP_HASH"));
-		todos.Enqueue(new TodoModel("y.DDS", string.Empty, Path.Combine(settings.SourceFolder, "y.DDS"), settings.TargetFolder, "DUP_HASH"));
+		todos.Enqueue(new TodoModel("x.DDS", string.Empty, Path.Combine(settings.SourceFolder, "x.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "x.DDS"));
+		todos.Enqueue(new TodoModel("y.DDS", string.Empty, Path.Combine(settings.SourceFolder, "y.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "y.DDS"));
 
 		TodoService sut = CreateSut();
 
@@ -198,7 +248,7 @@ public sealed class TodoServiceTests
 	}
 
 	[TestMethod]
-	public void GetTodosDoneManualWithRetainStructureKeepsFolderAndFileName()
+	public void GetTodosDoneManualWithRetainStructureKeepsFolderAndFileNameAndWritesJson()
 	{
 		ConfigureCommonMocks();
 		SetupCanvas(64, 64);
@@ -207,15 +257,17 @@ public sealed class TodoServiceTests
 
 		string relativePath = $"{Path.DirectorySeparatorChar}Blue";
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("64.DDS", relativePath, Path.Combine(settings.SourceFolder, "Blue", "64.DDS"), settings.TargetFolder, "HASH_A"));
+		todos.Enqueue(new TodoModel("64.DDS", relativePath, Path.Combine(settings.SourceFolder, "Blue", "64.DDS"), settings.TargetFolder, "HASH_A", ImageType.DDS, "64.DDS"));
 
 		TodoService sut = CreateSut();
 
 		sut.GetTodosDone(todos, settings);
 
 		string expectedSavePath = Path.Combine($"{settings.TargetFolder}{relativePath}", "64.PNG");
+		string expectedJsonPath = Path.Combine(settings.TargetFolder, "Result.json");
 
 		_fileProviderMock.Verify(x => x.WriteAllBytes(expectedSavePath, It.IsAny<byte[]>()), Times.Once);
+		_fileProviderMock.Verify(x => x.WriteAllText(expectedJsonPath, It.IsAny<string>()), Times.Once);
 	}
 
 	[TestMethod]
@@ -227,7 +279,7 @@ public sealed class TodoServiceTests
 		settings.SeparateBySize = true;
 
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("64.DDS", string.Empty, Path.Combine(settings.SourceFolder, "64.DDS"), settings.TargetFolder, "HASH_A"));
+		todos.Enqueue(new TodoModel("64.DDS", string.Empty, Path.Combine(settings.SourceFolder, "64.DDS"), settings.TargetFolder, "HASH_A", ImageType.DDS, "64.DDS"));
 
 		TodoService sut = CreateSut();
 
@@ -246,7 +298,7 @@ public sealed class TodoServiceTests
 		ConvertSettings settings = CreateSettings(ConvertModeType.Manual);
 
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("64.DDS", string.Empty, Path.Combine(settings.SourceFolder, "64.DDS"), settings.TargetFolder, "HASH_A"));
+		todos.Enqueue(new TodoModel("64.DDS", string.Empty, Path.Combine(settings.SourceFolder, "64.DDS"), settings.TargetFolder, "HASH_A", ImageType.DDS, "64.DDS"));
 
 		TodoService sut = CreateSut();
 
@@ -256,7 +308,7 @@ public sealed class TodoServiceTests
 
 		_fileProviderMock.Verify(x => x.WriteAllBytes(expectedSavePath, It.IsAny<byte[]>()), Times.Once);
 
-		// The result json is only persisted in automatic mode.
+		// The result json is only persisted in automatic or name-preserving manual mode.
 		_fileProviderMock.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 	}
 
@@ -268,8 +320,8 @@ public sealed class TodoServiceTests
 		ConvertSettings settings = CreateSettings(ConvertModeType.Manual);
 
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH"));
-		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH"));
+		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "a.DDS"));
+		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "b.DDS"));
 
 		TodoService sut = CreateSut();
 
@@ -282,13 +334,34 @@ public sealed class TodoServiceTests
 	}
 
 	[TestMethod]
+	public void GetTodosDoneRestoreProcessesEveryLedgerEntryEvenOnDuplicateHashes()
+	{
+		ConfigureCommonMocks();
+		SetupCanvas(64, 64);
+		ConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
+		settings.Restore = true;
+
+		TodoCollection todos = new();
+		todos.Enqueue(new TodoModel("a.tga", "\\Blue", Path.Combine(settings.SourceFolder, "Blue", "a.PNG"), settings.TargetFolder, "DUP_HASH", ImageType.PNG, "a.tga") { TargetType = ImageType.TGA });
+		todos.Enqueue(new TodoModel("b.jpg", "\\Red", Path.Combine(settings.SourceFolder, "Red", "b.PNG"), settings.TargetFolder, "DUP_HASH", ImageType.PNG, "b.jpg") { TargetType = ImageType.JPG });
+
+		TodoService sut = CreateSut();
+
+		sut.GetTodosDone(todos, settings, jsonExists: true);
+
+		_fileProviderMock.Verify(x => x.WriteAllBytes(Path.Combine($"{settings.TargetFolder}\\Blue", "a.TGA"), It.IsAny<byte[]>()), Times.Once);
+		_fileProviderMock.Verify(x => x.WriteAllBytes(Path.Combine($"{settings.TargetFolder}\\Red", "b.JPG"), It.IsAny<byte[]>()), Times.Once);
+		_fileProviderMock.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+	}
+
+	[TestMethod]
 	public void GetTodosDoneWhenDecodeThrowsThrowsServiceExceptionAndLogs()
 	{
 		ConfigureCommonMocks();
 		ConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
 
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "HASH_A"));
+		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "HASH_A", ImageType.DDS, "a.DDS"));
 
 		_decoderMock.Setup(x => x.Decode(It.IsAny<byte[]>())).Throws(new InvalidOperationException("boom"));
 

--- a/tests/DDS.Tools.Tests/Services/TodoTransformationServiceTests.cs
+++ b/tests/DDS.Tools.Tests/Services/TodoTransformationServiceTests.cs
@@ -43,6 +43,34 @@ public sealed class TodoTransformationServiceTests
 	}
 
 	[TestMethod]
+	public void GetTodosDoneRestoreEncodesEachTodoToItsRecordedFormat()
+	{
+		ConfigureCommonMocks();
+		ConvertSettings settings = CreateSettings(ConvertModeType.Automatic);
+		settings.Restore = true;
+
+		TodoCollection todos = new();
+		todos.Enqueue(new TodoModel("64.tga", "\\Blue", Path.Combine(settings.SourceFolder, "Blue", "64.PNG"), settings.TargetFolder, "H1", ImageType.PNG, "64.tga")
+		{
+			TargetType = ImageType.TGA
+		});
+		todos.Enqueue(new TodoModel("64.jpg", "\\Red", Path.Combine(settings.SourceFolder, "Red", "64.PNG"), settings.TargetFolder, "H2", ImageType.PNG, "64.jpg")
+		{
+			TargetType = ImageType.JPG
+		});
+
+		TodoTransformationService sut = CreateSut();
+
+		TodoProcessingResult result = sut.GetTodosDone(todos, settings);
+
+		Assert.AreEqual(2, result.TodosDoneCount);
+		_codecRegistryMock.Verify(x => x.GetEncoder(ImageType.TGA), Times.Once);
+		_codecRegistryMock.Verify(x => x.GetEncoder(ImageType.JPG), Times.Once);
+		_fileProviderMock.Verify(x => x.WriteAllBytes(Path.Combine($"{settings.TargetFolder}\\Blue", "64.TGA"), It.IsAny<byte[]>()), Times.Once);
+		_fileProviderMock.Verify(x => x.WriteAllBytes(Path.Combine($"{settings.TargetFolder}\\Red", "64.JPG"), It.IsAny<byte[]>()), Times.Once);
+	}
+
+	[TestMethod]
 	[DataRow(ConvertModeType.Automatic)]
 	[DataRow(ConvertModeType.Grouping)]
 	public void GetTodosDoneCountsDuplicatesSeparately(ConvertModeType convertMode)
@@ -76,8 +104,8 @@ public sealed class TodoTransformationServiceTests
 	private static TodoCollection CreateDuplicateTodos(ConvertSettings settings)
 	{
 		TodoCollection todos = new();
-		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH"));
-		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH"));
+		todos.Enqueue(new TodoModel("a.DDS", string.Empty, Path.Combine(settings.SourceFolder, "a.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "a.DDS"));
+		todos.Enqueue(new TodoModel("b.DDS", string.Empty, Path.Combine(settings.SourceFolder, "b.DDS"), settings.TargetFolder, "DUP_HASH", ImageType.DDS, "b.DDS"));
 
 		return todos;
 	}


### PR DESCRIPTION
…te docs

- Added `--restore` flag for round-trip file restoration in DDS.Tools.
- Updated README.md with `--restore` docs, clarified options, and added usage examples.
- Made `--from` optional; processes all recognized formats if omitted.
- `--to` is not required with `--restore`; validation prevents `--from` + `--restore`.
- Enhanced `TodoModel` to track original file name/format and per-file targets.
- Improved todo planning and transformation for accurate restoration and ledger writing.
- Improved error handling for missing/invalid result ledgers during restore.
- Expanded unit tests for restore workflow, mixed formats, validation, and restoration.
- Refactored and removed obsolete source format inference logic.

closes #283